### PR TITLE
Release a stream's read buffer after a large message is handed off

### DIFF
--- a/.changes/unreleased/Fixed-20260911-120000.yaml
+++ b/.changes/unreleased/Fixed-20260911-120000.yaml
@@ -1,0 +1,9 @@
+kind: Fixed
+body: |-
+    **Streams no longer keep a large message's allocation alive after handing
+    it over.** The server request reader and the client response stream slice
+    each message out of a shared read buffer, and the buffer kept a reference
+    to that allocation until the stream ended. A drained buffer larger than
+    64 KiB is now dropped, so the message is freed when the handler or caller
+    drops it and a stream of ordinary messages keeps reusing its buffer.
+time: 2026-09-11T12:00:00.000000000+00:00

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -2971,11 +2971,14 @@ where
                 // so signal that more data is needed.
                 None
             } else {
-                Envelope::decode_with_limit(
+                let len_before_decode = self.buf.len();
+                let envelope = Envelope::decode_with_limit(
                     &mut self.buf,
                     self.max_message_size
                         .unwrap_or(crate::service::DEFAULT_MAX_MESSAGE_SIZE),
-                )?
+                )?;
+                crate::envelope::release_drained_buf(&mut self.buf, len_before_decode);
+                envelope
             };
 
             match envelope_result {
@@ -6129,6 +6132,145 @@ mod tests {
             .expect("raising the stream's budget must admit the same envelope")
             .expect("the envelope carries a data frame");
         assert_eq!(msg.view().values.len(), n);
+    }
+
+    /// A large streamed message is the sole owner of its allocation: the
+    /// stream keeps no reference to it.
+    #[tokio::test]
+    async fn server_stream_releases_buffer_after_large_message() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+        use http_body::Frame;
+        use http_body_util::StreamBody;
+
+        const LEN: usize = 1024 * 1024;
+        let message = StringValue {
+            value: "x".repeat(LEN),
+            ..Default::default()
+        };
+        let wire = Envelope::data(message.encode_to_bytes()).encode();
+        let frames: Vec<Result<Frame<Bytes>, std::convert::Infallible>> = wire
+            .chunks(16 * 1024)
+            .map(|chunk| Ok(Frame::data(Bytes::copy_from_slice(chunk))))
+            .collect();
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
+            headers: http::HeaderMap::new(),
+            body: StreamBody::new(futures::stream::iter(frames)),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Connect,
+            max_message_size: Some(4 * LEN),
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let msg = stream
+            .message()
+            .await
+            .expect("message should decode")
+            .expect("stream should yield the data envelope");
+        assert_eq!(msg.view().value.len(), LEN, "message must arrive intact");
+        assert_eq!(
+            stream.buf.capacity(),
+            0,
+            "stream still holds the large message's allocation"
+        );
+        assert!(
+            msg.bytes().is_unique(),
+            "stream still shares the allocation with the message"
+        );
+    }
+
+    /// A message that arrives in one frame leaves no spare capacity behind,
+    /// so only the buffered length can show that the allocation is large.
+    #[tokio::test]
+    async fn server_stream_releases_exactly_sized_buffer() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        const LEN: usize = 128 * 1024;
+        let message = StringValue {
+            value: "x".repeat(LEN),
+            ..Default::default()
+        };
+        let wire = Envelope::data(message.encode_to_bytes()).encode();
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
+            headers: http::HeaderMap::new(),
+            body: Full::new(wire),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Connect,
+            max_message_size: Some(4 * LEN),
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let msg = stream
+            .message()
+            .await
+            .expect("message should decode")
+            .expect("stream should yield the data envelope");
+        assert_eq!(msg.view().value.len(), LEN, "message must arrive intact");
+        assert!(
+            msg.bytes().is_unique(),
+            "stream still shares the allocation with the message"
+        );
+    }
+
+    /// A small read buffer is kept for reuse.
+    #[tokio::test]
+    async fn server_stream_keeps_small_buffer() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let message = StringValue {
+            value: "hello".to_owned(),
+            ..Default::default()
+        };
+        let wire = Envelope::data(message.encode_to_bytes()).encode();
+
+        let mut stream: ServerStream<_, StringValueView<'static>> = ServerStream {
+            element_memory_limit: None,
+            headers: http::HeaderMap::new(),
+            body: Full::new(wire),
+            buf: BytesMut::new(),
+            encoding: None,
+            compression: CompressionRegistry::new(),
+            codec_format: CodecFormat::Proto,
+            protocol: Protocol::Connect,
+            max_message_size: None,
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        };
+
+        let msg = stream
+            .message()
+            .await
+            .expect("message should decode")
+            .expect("stream should yield the data envelope");
+        assert_eq!(msg.view().value, "hello");
+        assert!(stream.buf.is_empty(), "the only message was handed over");
+        assert!(
+            !msg.bytes().is_unique(),
+            "a small read buffer should be kept for reuse"
+        );
     }
 
     #[tokio::test]

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -32,6 +32,34 @@ pub mod flags {
 /// Size of the envelope header in bytes.
 pub const HEADER_SIZE: usize = 5;
 
+/// Largest drained read buffer a stream keeps for reuse between messages.
+///
+/// Well above h2's default 16 KiB `max_frame_size`, so a stream of ordinary
+/// messages keeps reusing one buffer. Above it, each message costs one
+/// buffer re-grow: a deliberate trade, since the alternative is a stream
+/// pinning a multi-MiB allocation until it ends. The threshold is fixed
+/// rather than a `Limits` knob because nothing so far has needed to tune it.
+pub(crate) const MAX_RETAINED_READ_BUF: usize = 64 * 1024;
+
+/// Drops a drained read buffer larger than [`MAX_RETAINED_READ_BUF`], so the
+/// messages sliced from it become the only owners of its allocation and it
+/// is freed with them rather than at the end of the stream.
+///
+/// Call it once per body frame, after decoding everything the buffer holds,
+/// with `len_before_decode` captured as `buf.len()` before the first decode:
+/// a lower bound on the allocation's size that still holds when a decode
+/// splits the whole buffer off and leaves `capacity()` at zero. The check is
+/// best-effort: a buffer that always carries a partial message keeps its
+/// allocation until it drains, and a large allocation whose remaining window
+/// is small is kept until `BytesMut::reserve` reclaims it, after which the
+/// `capacity()` term catches it. Compressed streams gain nothing from the
+/// release (decompression already copies) and pay only the re-grow.
+pub(crate) fn release_drained_buf(buf: &mut BytesMut, len_before_decode: usize) {
+    if buf.is_empty() && len_before_decode.max(buf.capacity()) > MAX_RETAINED_READ_BUF {
+        *buf = BytesMut::new();
+    }
+}
+
 /// Minimum payload size for chaining a payload as its own body frame
 /// instead of copying it into the contiguous framing buffer.
 ///
@@ -148,6 +176,11 @@ impl Envelope {
     ///
     /// This protects against malicious clients declaring very large message
     /// sizes in the envelope header.
+    ///
+    /// The returned `data` is a slice of `buf`'s allocation, not a copy, so
+    /// the allocation lives until both it and `buf` are dropped. A caller
+    /// that keeps `buf` across many messages should replace it once it is
+    /// drained if it has grown large, so the messages become its sole owners.
     pub fn decode_with_limit(
         buf: &mut BytesMut,
         max_size: usize,
@@ -463,6 +496,32 @@ mod tests {
             None,
             Arc::new(CompressionRegistry::default()),
         )
+    }
+
+    /// A drained buffer is released only once its allocation exceeds the
+    /// retained size, whether the buffered length or the capacity shows it.
+    #[test]
+    fn release_drained_buf_releases_only_large_drained_buffers() {
+        let mut buf = BytesMut::with_capacity(MAX_RETAINED_READ_BUF);
+        release_drained_buf(&mut buf, MAX_RETAINED_READ_BUF);
+        assert!(buf.capacity() > 0, "a buffer at the threshold is kept");
+
+        let mut buf = BytesMut::with_capacity(MAX_RETAINED_READ_BUF + 1);
+        release_drained_buf(&mut buf, 0);
+        assert_eq!(buf.capacity(), 0, "a large capacity alone releases");
+
+        let mut buf = BytesMut::new();
+        release_drained_buf(&mut buf, MAX_RETAINED_READ_BUF + 1);
+        assert_eq!(buf.capacity(), 0, "a large buffered length alone releases");
+    }
+
+    #[test]
+    fn release_drained_buf_keeps_buffers_holding_data() {
+        let mut buf = BytesMut::with_capacity(2 * MAX_RETAINED_READ_BUF);
+        buf.extend_from_slice(b"partial envelope");
+        release_drained_buf(&mut buf, 2 * MAX_RETAINED_READ_BUF);
+        assert_eq!(&buf[..], b"partial envelope");
+        assert!(buf.capacity() >= 2 * MAX_RETAINED_READ_BUF);
     }
 
     // ── Envelope tests ──────────────────────────────────────────────

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -2923,7 +2923,9 @@ impl BodyReader {
         match &mut self.mode {
             ReadMode::Decoding => {
                 self.buf.extend_from_slice(&data);
+                let len_before_decode = self.buf.len();
                 self.decode_available().await;
+                crate::envelope::release_drained_buf(&mut self.buf, len_before_decode);
                 ControlFlow::Continue(())
             }
             ReadMode::Draining {
@@ -5414,6 +5416,222 @@ mod tests {
             pulled <= max_expected,
             "reader pulled {pulled} bytes after END_STREAM (expected at most \
              {max_expected}); trailing data is being buffered without bound"
+        );
+    }
+
+    /// A large message handed to the handler is the sole owner of its
+    /// allocation: the reader keeps no reference to it.
+    #[tokio::test]
+    async fn test_body_reader_releases_buffer_after_large_message() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut reader = BodyReader::new(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            None,
+            Arc::new(CompressionRegistry::new()),
+            tx,
+        );
+
+        let payload = Bytes::from(vec![0x42_u8; 1024 * 1024]);
+        let wire = Envelope::data(payload.clone()).encode();
+        for chunk in wire.chunks(16 * 1024) {
+            assert!(
+                reader
+                    .on_data(Bytes::copy_from_slice(chunk))
+                    .await
+                    .is_continue(),
+                "reader must keep reading while decoding"
+            );
+        }
+
+        let msg = rx.recv().await.expect("message").expect("decodes");
+        assert_eq!(msg, payload, "message must arrive intact");
+        assert_eq!(
+            reader.buf.capacity(),
+            0,
+            "reader still holds the large message's allocation"
+        );
+        assert!(
+            msg.is_unique(),
+            "reader still shares the allocation with the message"
+        );
+    }
+
+    /// A message that arrives in one frame leaves no spare capacity behind,
+    /// so only the buffered length can show that the allocation is large.
+    #[tokio::test]
+    async fn test_body_reader_releases_exactly_sized_buffer() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut reader = BodyReader::new(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            None,
+            Arc::new(CompressionRegistry::new()),
+            tx,
+        );
+
+        let payload = Bytes::from(vec![0x42_u8; 128 * 1024]);
+        let wire = Envelope::data(payload.clone()).encode();
+        assert!(
+            reader.on_data(wire).await.is_continue(),
+            "reader must keep reading while decoding"
+        );
+
+        let msg = rx.recv().await.expect("message").expect("decodes");
+        assert_eq!(msg, payload, "message must arrive intact");
+        assert!(
+            msg.is_unique(),
+            "reader still shares the allocation with the message"
+        );
+    }
+
+    /// When the frame that completes a large message also carries the start
+    /// of the next one, both arrive in order and the buffer is released once
+    /// the second message has drained it.
+    #[tokio::test]
+    async fn test_body_reader_releases_buffer_after_trailing_partial_message() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut reader = BodyReader::new(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            None,
+            Arc::new(CompressionRegistry::new()),
+            tx,
+        );
+
+        let large = Bytes::from(vec![0x42_u8; 1024 * 1024]);
+        let small = Bytes::from(vec![0x43_u8; 100]);
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::data(large.clone()).encode());
+        wire.extend_from_slice(&Envelope::data(small.clone()).encode());
+        let rest = wire.split_off(wire.len() - 50);
+
+        for chunk in wire.chunks(16 * 1024) {
+            assert!(
+                reader
+                    .on_data(Bytes::copy_from_slice(chunk))
+                    .await
+                    .is_continue(),
+                "reader must keep reading while decoding"
+            );
+        }
+        let first = rx.recv().await.expect("first message").expect("decodes");
+        assert_eq!(first, large, "large message must arrive first and intact");
+        assert!(
+            !reader.buf.is_empty(),
+            "start of the second message must stay buffered"
+        );
+
+        assert!(
+            reader.on_data(rest.freeze()).await.is_continue(),
+            "reader must keep reading while decoding"
+        );
+        let second = rx.recv().await.expect("second message").expect("decodes");
+        assert_eq!(second, small, "small message must arrive second and intact");
+        assert_eq!(
+            reader.buf.capacity(),
+            0,
+            "reader still holds the large message's allocation"
+        );
+        drop(second);
+        assert!(
+            first.is_unique(),
+            "reader still shares the allocation with the messages"
+        );
+    }
+
+    /// When a large message leaves its allocation almost full and the next
+    /// message is already partly buffered, the allocation stays until the
+    /// reader reclaims it; the drain after that releases it.
+    #[tokio::test]
+    async fn test_body_reader_releases_reclaimed_buffer() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut reader = BodyReader::new(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            None,
+            Arc::new(CompressionRegistry::new()),
+            tx,
+        );
+
+        // The large envelope plus the first 10 bytes of the next one fill a
+        // 1 MiB allocation to within 30 bytes.
+        let large = Bytes::from(vec![0x41_u8; 1024 * 1024 - 45]);
+        let small = Bytes::from(vec![0x42_u8; 15]);
+        let last = Bytes::from(vec![0x43_u8; 100]);
+        let small_wire = Envelope::data(small.clone()).encode();
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::data(large.clone()).encode());
+        wire.extend_from_slice(&small_wire[..10]);
+
+        for chunk in wire.chunks(16 * 1024) {
+            assert!(
+                reader
+                    .on_data(Bytes::copy_from_slice(chunk))
+                    .await
+                    .is_continue(),
+                "reader must keep reading while decoding"
+            );
+        }
+        let first = rx.recv().await.expect("first message").expect("decodes");
+        assert_eq!(first, large, "large message must arrive first and intact");
+        assert_eq!(
+            reader.buf.len(),
+            10,
+            "start of the second message must stay buffered"
+        );
+
+        assert!(
+            reader.on_data(small_wire.slice(10..)).await.is_continue(),
+            "reader must keep reading while decoding"
+        );
+        let second = rx.recv().await.expect("second message").expect("decodes");
+        assert_eq!(second, small, "small message must arrive second and intact");
+        drop(second);
+        assert!(
+            !first.is_unique(),
+            "a drained buffer with a small tail is kept until it is reclaimed"
+        );
+
+        drop(first);
+        assert!(
+            reader
+                .on_data(Envelope::data(last.clone()).encode())
+                .await
+                .is_continue(),
+            "reader must keep reading while decoding"
+        );
+        let third = rx.recv().await.expect("third message").expect("decodes");
+        assert_eq!(third, last, "last message must arrive intact");
+        assert_eq!(
+            reader.buf.capacity(),
+            0,
+            "reader still holds the reclaimed allocation"
+        );
+        assert!(
+            third.is_unique(),
+            "reader still shares the allocation with the message"
+        );
+    }
+
+    /// A small read buffer is kept for reuse.
+    #[tokio::test]
+    async fn test_body_reader_keeps_small_buffer() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut reader = BodyReader::new(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            None,
+            Arc::new(CompressionRegistry::new()),
+            tx,
+        );
+
+        let wire = Envelope::data(Bytes::from_static(b"hello")).encode();
+        assert!(
+            reader.on_data(wire).await.is_continue(),
+            "reader must keep reading while decoding"
+        );
+
+        let msg = rx.recv().await.expect("message").expect("decodes");
+        assert!(reader.buf.is_empty(), "the only message was handed over");
+        assert!(
+            !msg.is_unique(),
+            "a small read buffer should be kept for reuse"
         );
     }
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -751,7 +751,10 @@ The handler receives an `InboundStream<Req>` — a `ServiceStream` of
 `StreamMessage<Req>` items — and returns a single response. Each item
 owns its decoded buffer, is `Send + 'static` (so it can be buffered or
 moved into spawned tasks), and exposes zero-copy accessor methods per
-field:
+field. That buffer is a slice of the stream's read buffer, so a small
+item cut from a large read keeps the whole allocation alive while it is
+held; a handler that retains many items past the loop should keep
+`to_owned_message()` results rather than the items themselves:
 
 ```rust
 async fn sum(


### PR DESCRIPTION
## The problem

On client-streaming and bidi requests the server's body reader keeps one `BytesMut` for the whole stream. Each uncompressed message is handed to the handler as `buf.split_to(len).freeze()`, a zero-copy slice of that buffer's allocation. (A compressed message is decompressed into a buffer of its own; the reader's buffer is retained in the same way.) The reader keeps the rest of the allocation, the unused tail, for the next message. Two properties of `BytesMut` then combine:

- it never shrinks;
- when the tail runs out and no slice is outstanding, `reserve` reclaims the whole allocation and reuses it.

So the allocation stays alive, at the size of the largest message seen so far, until the stream ends. This holds even when the handler dropped that message long ago. Growth is by doubling, so the allocation can be up to twice the message.

Example, within the default 4 MiB `max_message_size`: a 3 MiB first message on a long-lived stream, followed only by small messages, keeps an allocation of about 4 MiB until the stream ends. With the limit raised, a 16 MiB first message keeps about 32 MiB. A server with many long-lived streams that each begin with one large message holds that memory for every open stream.

`ServerStream` on the client does the same with the response body.

Nothing a handler or caller can do releases the buffer, short of ending the stream. `Limits` bounds how large a message may be, not how long its buffer lives.

## The fix

After decoding, if the read buffer is empty and was larger than 64 KiB, replace it with `BytesMut::new()`. The messages already handed out become the only owners of the allocation, so it is freed when the handler (or caller) drops them. The next message starts a fresh buffer.

`BodyReader::enter_drain_mode` already replaces the buffer when the request stream ends, "instead of keeping them resident for the duration of the drain". This change applies the same idea between messages.

The helper `release_drained_buf` lives in `envelope.rs`. It is called from `BodyReader::on_data` (server) and from `ServerStream::next_message_or_end` (client). No public API changes.

## The 64 KiB guard

Replacing the buffer every time it is empty would make a stream of small messages pay two small allocations per message (a new `Vec`, plus the shared header that `split_to` allocates), where today it can reuse one buffer. With the guard, a stream of small messages read in ordinary-sized frames behaves exactly as before. (If such a stream is read in frames larger than 64 KiB, it gets one new allocation per such frame.)

The guard compares `max(bytes buffered before decoding, remaining capacity)` with the threshold. `capacity()` on its own is not enough: after `split_to` it reports only the unused tail, which can be zero while the buffer still pins a large allocation. The bytes buffered before decoding are a lower bound on the allocation's size. The capacity term catches a buffer that `reserve` reclaimed whole, and a large tail left after a message when the next one is already partly buffered.

64 KiB is well above h2's default 16 KiB `max_frame_size`. It is also the largest "original capacity" that `bytes` itself restores when a shared `BytesMut` has to reallocate (`MAX_ORIGINAL_CAPACITY_WIDTH` in `bytes_mut.rs`).

## Measured

A server with about 130 open streams, each carrying one 16 MiB message first and small ones after it, heap-profiled for 35 seconds, one run before and one after (the `max_message_size` limit was raised for the test):

- read buffer held per open stream: 32 MiB before, 0 after;
- heap allocated per open stream: 52.6 MiB before, 20.6 MiB after;
- process RSS per open stream: about 33 MiB before, about 17 MiB after. The buffer reserved twice the message and wrote half of it, so resident memory falls by about one message per stream.

After the streams ended both builds returned to the same level.

## Cost

A stream whose messages are all large now starts a fresh buffer for each message and grows it by doubling. Before, it could reuse one allocation when the handler had already dropped the previous message. I have not measured this with the repository's benches, and I am happy to.

## Left out on purpose

- Reserving the exact message size once the 5-byte envelope header has arrived. It would avoid the doubling, and the repeated grow-and-copy while a large message arrives. But it would let a peer make the receiver allocate up to `max_message_size` after sending five bytes; today memory follows the bytes actually received. That deserves its own discussion.
- Avoiding the copy in `extend_from_slice` when one body frame holds a whole message.

## Limits of the fix

The release needs the buffer to be empty after a body frame, and at that moment either the bytes just decoded or the unused tail must be above 64 KiB. If the last frame of a large message also carries the start of the next one, and the allocation's unused tail is 64 KiB or less, neither holds. The allocation then stays until that tail is used up (at most 64 KiB of further data); a stream that goes idle first keeps it, as today. It is never worse than today.

An exact variant is possible: keep a per-stream high-water mark of `buf.len()`, reset on release, as one more field in `BodyReader` and in `ServerStream`. I left it out to keep the change small; say if you prefer it.

## Also in this change

- A changelog entry under `.changes/unreleased/`.
- A note in the client-streaming guide: an item is a slice of the stream's read buffer, so a handler that keeps many items past the loop should keep `to_owned_message()` results.

## Tests

Server (`service.rs`, next to the other `test_body_reader_*` tests):

- `test_body_reader_releases_buffer_after_large_message`: a 1 MiB message arrives in 16 KiB frames. Afterwards the reader's buffer has capacity 0 and the received `Bytes` `is_unique()`.
- `test_body_reader_releases_exactly_sized_buffer`: a 128 KiB message arrives in one frame, so the buffer is sized exactly and has no tail. Only the "bytes buffered" term of the guard can release it. (With a capacity-only guard this test fails.)
- `test_body_reader_releases_buffer_after_trailing_partial_message`: the frame that completes a 1 MiB message also carries the start of a small one. Both arrive in order, and the buffer is released when the small one has drained it. Only the capacity term can do that. (With a buffered-only guard this test and the next one fail.)
- `test_body_reader_releases_reclaimed_buffer`: the limit described above. A large message fills its allocation to within 30 bytes and the next message is partly buffered, so the buffer is kept when it drains. Once the handler has dropped the messages and a later message makes the reader reclaim the allocation, the next drain releases it.
- `test_body_reader_keeps_small_buffer`: after a small message the buffer is still shared with the message, so it is kept for reuse.

Client (`client/mod.rs`): `server_stream_releases_buffer_after_large_message` and `server_stream_releases_exactly_sized_buffer`, the same two cases for `ServerStream`.

With the release turned into a no-op, all six "releases" tests fail and the "keeps small buffer" test passes. With the change, `cargo test --all-features` on the crate passes (688 unit tests and 9 doc tests on the 0.9.0 sources), and `cargo clippy --all-features --all-targets` and `cargo fmt --check` (default settings) report nothing. The conformance suite is not part of the published crate, so I did not run it locally; CI on this pull request runs it against main.

The tests rely on `Bytes::is_unique`. It exists from bytes 1.6.0, the crate's current minimum, but bytes 1.6.1 fixed it returning wrong values for a `Bytes` that came from a shared `BytesMut`, which is what these tests check. So in practice they need 1.6.1; you may or may not want to raise the floor.