### PR TITLE
Assemble streamed messages per message instead of slicing a per-stream read buffer

### DIFF
--- a/.changes/unreleased/Fixed-20260912-000000.yaml
+++ b/.changes/unreleased/Fixed-20260912-000000.yaml
@@ -1,0 +1,18 @@
+kind: Fixed
+body: |-
+    **Streams no longer keep a large message's allocation alive after handing
+    it over.** The server request reader and the client response stream used
+    to slice each message out of a per-stream read buffer that grew to the
+    largest message and was kept until the stream ended, so a long-lived
+    stream that once carried a multi-MiB message pinned that memory even after
+    the handler dropped it. Messages are now assembled straight from transport
+    frames: a message larger than 4 KiB gets its own exactly-sized buffer that
+    it solely owns, and the size limit is still checked before anything is
+    allocated. Messages of 4 KiB or less are copied out of a small reusable
+    per-stream buffer, so steady-state small messages do not allocate; an idle
+    stream retains at most 8 KiB. No API or wire change. The client-side
+    "response buffer exceeds limit" error is gone (memory is now bounded per
+    envelope, whose over-limit header reports "message size N exceeds limit M"
+    as before), and a gRPC-Web trailer frame larger than 1 MiB now fails the
+    stream with `resource_exhausted`.
+time: 2026-09-12T00:00:00.000000000+00:00

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["network-programming", "web-programming::http-server", "web-progra
 http = "1"
 http-body = "1"
 http-body-util = "0.1"
-bytes = { version = "1.6", features = ["serde"] }
+bytes = { version = "1.6.1", features = ["serde"] }
 
 # Tower service abstraction
 tower = { version = "0.5", features = ["util", "buffer"] }

--- a/connectrpc/src/client/mod.rs
+++ b/connectrpc/src/client/mod.rs
@@ -173,6 +173,7 @@ use crate::codec::header as connect_header;
 use crate::compression::CompressionPolicy;
 use crate::compression::CompressionRegistry;
 use crate::envelope::Envelope;
+use crate::envelope::EnvelopeAssembler;
 use crate::error::ConnectError;
 use crate::error::ErrorCode;
 use crate::error::ErrorDetail;
@@ -243,6 +244,23 @@ where
 /// generous: the gRPC best-practices guide recommends keeping metadata
 /// under 8 KiB per header set.
 const RESPONSE_BUFFER_TRAILER_SLACK: usize = 64 * 1024;
+
+/// Largest gRPC-Web trailer frame payload the client accepts. Caps what a
+/// malicious server can make the client allocate for trailer metadata; 1 MiB
+/// is generous for a trailer block. Distinct from
+/// [`RESPONSE_BUFFER_TRAILER_SLACK`], which only sizes the unary buffer.
+const MAX_GRPC_WEB_TRAILER_SIZE: usize = 1024 * 1024;
+
+/// The envelope assembler for a streaming response body.
+fn response_assembler(protocol: Protocol, max_message_size: usize) -> EnvelopeAssembler {
+    let assembler = EnvelopeAssembler::new(max_message_size);
+    match protocol {
+        // The trailer frame is metadata, bounded by the trailer parser's own
+        // limit rather than the message size.
+        Protocol::GrpcWeb => assembler.with_grpc_web_trailer_limit(MAX_GRPC_WEB_TRAILER_SIZE),
+        _ => assembler,
+    }
+}
 
 /// Return the end offset of a complete gRPC-Web trailer frame, if present.
 fn grpc_web_trailer_frame_end(data: &[u8]) -> Option<usize> {
@@ -2760,8 +2778,8 @@ impl From<ConnectError> for StreamEnd {
 
 /// What one body poll produced.
 enum BodyPoll {
-    /// A DATA frame was appended to the decode buffer.
-    Data,
+    /// A DATA frame.
+    Data(Bytes),
     /// HTTP/2 (or HTTP/1.1 chunked) trailers — the body's final frame.
     Trailers(http::HeaderMap),
     /// Body exhausted.
@@ -2791,12 +2809,16 @@ enum BodyPoll {
 pub struct ServerStream<B, RespView> {
     headers: http::HeaderMap,
     body: B,
-    buf: BytesMut,
+    /// Unconsumed remainder of the current body DATA frame. When one frame
+    /// carries several envelopes this keeps the transport's read block alive
+    /// between `message()` calls, until the next poll or drop.
+    frame: Bytes,
+    assembler: EnvelopeAssembler,
     encoding: Option<String>,
     compression: CompressionRegistry,
     codec_format: CodecFormat,
     protocol: Protocol,
-    max_message_size: Option<usize>,
+    max_message_size: usize,
     element_memory_limit: Option<usize>,
     deadline: Option<std::time::Instant>,
     /// The terminal record; `Some` once the stream has ended, by any cause.
@@ -2820,7 +2842,7 @@ impl<B, RespView> ServerStream<B, RespView> {
 }
 
 // Manual impl: the body type `B` (typically `hyper::body::Incoming`) isn't
-// `Debug`, and we don't want to dump the partially-consumed `buf` anyway.
+// `Debug`, and we don't want to dump the partially-consumed frame anyway.
 // Print the stream's observable state for test diagnostics.
 impl<B, RespView> std::fmt::Debug for ServerStream<B, RespView> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -2837,7 +2859,7 @@ impl<B, RespView> std::fmt::Debug for ServerStream<B, RespView> {
                 "has_trailers",
                 &self.end.as_ref().is_some_and(|e| e.trailers.is_some()),
             )
-            .field("buffered_bytes", &self.buf.len())
+            .field("frame_bytes", &self.frame.len())
             .finish_non_exhaustive()
     }
 }
@@ -2930,84 +2952,13 @@ where
     /// producing the terminal record.
     async fn next_message_or_end(&mut self) -> Result<OwnedView<RespView>, StreamEnd> {
         loop {
-            // For gRPC-Web, check for a complete trailer frame (flag 0x80)
-            // before attempting envelope decode (which would treat 0x80 as
-            // a data envelope flag rather than the gRPC-Web trailer sentinel).
-            if matches!(self.protocol, Protocol::GrpcWeb)
-                && self.buf.len() >= 5
-                && self.buf[0] & crate::envelope::flags::GRPC_WEB_TRAILER != 0
-            {
-                let trailer_len =
-                    u32::from_be_bytes([self.buf[1], self.buf[2], self.buf[3], self.buf[4]])
-                        as usize;
-                // `saturating_add`: `trailer_len` is a server-controlled u32, so
-                // on a 32-bit target (e.g. the supported `wasm32` gRPC-Web
-                // client) `5 + trailer_len` can overflow `usize` and panic in a
-                // debug build. Matches the sibling framing sites, which already
-                // saturate. A saturated sum is never `<= buf.len()`, so an
-                // over-large prefix simply waits for bytes that never arrive.
-                if self.buf.len() >= trailer_len.saturating_add(5) {
-                    // Complete trailer frame — parse and classify. An
-                    // unparseable frame classifies as `None` (no usable
-                    // termination metadata).
-                    let decompression =
-                        self.encoding.as_deref().map(|enc| (&self.compression, enc));
-                    let parsed =
-                        parse_grpc_web_trailer_frame_with_compression(&self.buf, decompression);
-                    return Err(self.classify_grpc_end(parsed));
-                }
-                // Incomplete trailer frame — need more data, fall through
-                // to poll_body below
-            }
-
-            // Try to decode a complete envelope from the buffer.
-            // Skip this for gRPC-Web when the buffer starts with 0x80 (trailer
-            // flag) to avoid misinterpreting the trailer frame as a data message.
-            let envelope_result = if matches!(self.protocol, Protocol::GrpcWeb)
-                && !self.buf.is_empty()
-                && self.buf[0] & crate::envelope::flags::GRPC_WEB_TRAILER != 0
-            {
-                // We know the trailer frame is incomplete (checked above),
-                // so signal that more data is needed.
-                None
-            } else {
-                Envelope::decode_with_limit(
-                    &mut self.buf,
-                    self.max_message_size
-                        .unwrap_or(crate::service::DEFAULT_MAX_MESSAGE_SIZE),
-                )?
-            };
-
-            match envelope_result {
-                Some(envelope) => {
-                    if envelope.is_end_stream() {
-                        // Connect protocol end-of-stream envelope
-                        return Err(self.process_end_stream(envelope));
-                    }
-
-                    // Data envelope — decompress and decode
-                    let data = self.decompress_envelope(envelope)?;
-
-                    // Check message size limit
-                    if let Some(max_size) = self.max_message_size
-                        && data.len() > max_size
-                    {
-                        return Err(ConnectError::new(
-                            ErrorCode::ResourceExhausted,
-                            format!("message size {} exceeds limit {}", data.len(), max_size),
-                        )
-                        .into());
-                    }
-
-                    let msg = decode_response_view::<RespView>(
-                        data,
-                        self.codec_format,
-                        &self.decode_options(),
-                    )?;
-                    return Ok(msg);
-                }
-                None => match self.poll_body().await? {
-                    BodyPoll::Data => {} // loop back to try decoding again
+            let Some(envelope) = self.assembler.feed(&mut self.frame)? else {
+                debug_assert!(
+                    self.frame.is_empty(),
+                    "feed returns None only on an empty frame"
+                );
+                match self.poll_body().await? {
+                    BodyPoll::Data(data) => self.frame = data,
                     BodyPoll::Trailers(trailers) => {
                         return Err(self.classify_grpc_end(Some(trailers)));
                     }
@@ -3023,28 +2974,41 @@ where
                             )
                             .into());
                         }
-                        // gRPC-Web: preserved verbatim from the
-                        // pre-refactor shape, and provably dead — the
-                        // loop-top completeness check consumes any complete
-                        // trailer frame before poll_body runs, and EOF
-                        // appends nothing, so the remnant here is absent or
-                        // incomplete and the parse returns `None`. Removal
-                        // is a follow-up; either way classification sees
-                        // "no usable termination metadata".
-                        let parsed = if matches!(self.protocol, Protocol::GrpcWeb)
-                            && !self.buf.is_empty()
-                            && self.buf[0] & crate::envelope::flags::GRPC_WEB_TRAILER != 0
-                        {
-                            let decompression =
-                                self.encoding.as_deref().map(|enc| (&self.compression, enc));
-                            parse_grpc_web_trailer_frame_with_compression(&self.buf, decompression)
-                        } else {
-                            None
-                        };
-                        return Err(self.classify_grpc_end(parsed));
+                        // gRPC / gRPC-Web with no HTTP trailers and no complete
+                        // trailer frame: no usable termination metadata.
+                        return Err(self.classify_grpc_end(None));
                     }
-                },
+                }
+                continue;
+            };
+
+            // gRPC-Web carries its trailers as a final 0x80-flagged frame in
+            // the body. (Plain gRPC does not define the bit; the streaming
+            // path ignores unknown flag bits, as it always has.)
+            if matches!(self.protocol, Protocol::GrpcWeb)
+                && envelope.flags & crate::envelope::flags::GRPC_WEB_TRAILER != 0
+            {
+                // An unparseable frame classifies as `None` (no usable
+                // termination metadata).
+                let decompression = self.encoding.as_deref().map(|enc| (&self.compression, enc));
+                let parsed = parse_grpc_web_trailer_payload(
+                    envelope.is_compressed(),
+                    &envelope.data,
+                    decompression,
+                );
+                return Err(self.classify_grpc_end(parsed));
             }
+
+            if envelope.is_end_stream() {
+                // Connect protocol end-of-stream envelope
+                return Err(self.process_end_stream(envelope));
+            }
+
+            // Data envelope — decompress (also bounded by `max_message_size`) and decode.
+            let data = self.decompress_envelope(envelope)?;
+            let msg =
+                decode_response_view::<RespView>(data, self.codec_format, &self.decode_options())?;
+            return Ok(msg);
         }
     }
 
@@ -3119,23 +3083,10 @@ where
     }
 
     /// Poll the body for the next frame. A pure transport reader: it
-    /// buffers data, returns trailers as a value, and never touches the
-    /// terminal record.
-    ///
-    /// Buffer growth is bounded: if the accumulated bytes exceed the expected
-    /// maximum in-flight envelope size, return `ResourceExhausted` rather than
-    /// continuing to buffer. This prevents a malicious server from trickling
-    /// bytes indefinitely without ever completing an envelope.
+    /// returns data and trailers as values and never touches the terminal
+    /// record. Memory is bounded by the assembler, which checks each
+    /// envelope's declared length before allocating for it.
     async fn poll_body(&mut self) -> Result<BodyPoll, ConnectError> {
-        // Enough for one complete envelope at the max message size, plus
-        // one header's worth of slack (next envelope's header may arrive in
-        // the same TCP frame), plus 64 KiB for gRPC-Web trailer frames.
-        let max_buf_size = self
-            .max_message_size
-            .unwrap_or(crate::service::DEFAULT_MAX_MESSAGE_SIZE)
-            .saturating_add(2 * crate::envelope::HEADER_SIZE)
-            .saturating_add(RESPONSE_BUFFER_TRAILER_SLACK);
-
         loop {
             // The whole-call deadline bounds each frame poll. The
             // equivalence with bounding the entire decode loop rests on
@@ -3160,13 +3111,7 @@ where
                             if !data.is_empty() {
                                 self.saw_body_data = true;
                             }
-                            if self.buf.len().saturating_add(data.len()) > max_buf_size {
-                                return Err(ConnectError::resource_exhausted(format!(
-                                    "response buffer exceeds limit {max_buf_size}"
-                                )));
-                            }
-                            self.buf.extend_from_slice(&data);
-                            return Ok(BodyPoll::Data);
+                            return Ok(BodyPoll::Data(data));
                         }
                     } else if frame.is_trailers()
                         && let Ok(trailers) = frame.into_trailers()
@@ -3197,11 +3142,8 @@ where
                     "received compressed message without content-encoding header",
                 )
             })?;
-            let max_size = self
-                .max_message_size
-                .unwrap_or(crate::service::DEFAULT_MAX_MESSAGE_SIZE);
             self.compression
-                .decompress_with_limit(encoding, envelope.data, max_size)
+                .decompress_with_limit(encoding, envelope.data, self.max_message_size)
                 .map_err(map_response_decompression_error)
         } else {
             Ok(envelope.data)
@@ -3368,6 +3310,7 @@ where
     RespView: MessageView<'static> + Send,
     RespView::Owned: buffa::Message + crate::codec::JsonDeserialize,
 {
+    let max_message_size = max_message_size.unwrap_or(crate::service::DEFAULT_MAX_MESSAGE_SIZE);
     let response_headers = response.headers().clone();
     let status = response.status();
 
@@ -3390,17 +3333,14 @@ where
                 .and_then(|v| v.to_str().ok())
                 .map(|s| s.to_owned());
 
-            let stream_max_err_size =
-                max_message_size.unwrap_or(crate::service::DEFAULT_MAX_MESSAGE_SIZE);
-
             let body =
-                collect_body_bounded(response.into_body(), stream_max_err_size, deadline).await?;
+                collect_body_bounded(response.into_body(), max_message_size, deadline).await?;
 
             // Decompress if the server set Content-Encoding. On failure,
             // fall through to the generic HTTP-status error below.
             let body = match error_encoding {
                 Some(encoding) => {
-                    match compression.decompress_with_limit(&encoding, body, stream_max_err_size) {
+                    match compression.decompress_with_limit(&encoding, body, max_message_size) {
                         Ok(decompressed) => Some(decompressed),
                         Err(e) => {
                             tracing::debug!(
@@ -3444,7 +3384,8 @@ where
         element_memory_limit,
         headers: response_headers,
         body: response.into_body(),
-        buf: BytesMut::new(),
+        frame: Bytes::new(),
+        assembler: response_assembler(protocol, max_message_size),
         encoding,
         compression: compression.clone(),
         codec_format,
@@ -4967,14 +4908,19 @@ fn parse_grpc_web_trailer_frame_with_compression(
     }
     let is_compressed = data[0] & crate::envelope::flags::COMPRESSED != 0;
     let len = u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize;
-    // Cap trailer frame size to prevent a malicious server from forcing
-    // unbounded memory allocation. 1 MB is generous for trailer metadata.
-    const MAX_TRAILER_SIZE: usize = 1024 * 1024;
-    if len > MAX_TRAILER_SIZE || data.len() < 5 + len {
+    if len > MAX_GRPC_WEB_TRAILER_SIZE || data.len() < len.saturating_add(5) {
         return None;
     }
-    let raw_payload = &data[5..5 + len];
+    parse_grpc_web_trailer_payload(is_compressed, &data[5..5 + len], decompression)
+}
 
+/// Parse the payload of a gRPC-Web trailer frame (the bytes after its 5-byte
+/// header) into a header map.
+fn parse_grpc_web_trailer_payload(
+    is_compressed: bool,
+    raw_payload: &[u8],
+    decompression: Option<(&CompressionRegistry, &str)>,
+) -> Option<http::HeaderMap> {
     // Decompress if the compressed flag is set
     let payload_bytes;
     let payload = if is_compressed {
@@ -4983,7 +4929,7 @@ fn parse_grpc_web_trailer_frame_with_compression(
                 .decompress_with_limit(
                     encoding,
                     Bytes::copy_from_slice(raw_payload),
-                    MAX_TRAILER_SIZE,
+                    MAX_GRPC_WEB_TRAILER_SIZE,
                 )
                 .ok()?;
             std::str::from_utf8(&payload_bytes).ok()?
@@ -5012,7 +4958,7 @@ fn parse_grpc_web_trailer_frame_with_compression(
             // `append` once the number of stored entries would exceed its
             // hard ceiling (`MAX_SIZE = 1 << 15`). A hostile server can pack
             // tens of thousands of short trailer lines into a payload that
-            // stays under `MAX_TRAILER_SIZE` (bytes, not entries), so the
+            // stays under `MAX_GRPC_WEB_TRAILER_SIZE` (bytes, not entries), so the
             // byte cap alone does not prevent the panic. Stop accumulating at
             // the ceiling rather than crashing the RPC task.
             if headers.try_append(name, val).is_err() {
@@ -6105,12 +6051,13 @@ mod tests {
             element_memory_limit,
             headers: http::HeaderMap::new(),
             body: Full::new(envelope.clone()),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(64 * 1024 * 1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Connect,
-            max_message_size: Some(64 * 1024 * 1024),
+            max_message_size: 64 * 1024 * 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6131,6 +6078,213 @@ mod tests {
         assert_eq!(msg.view().values.len(), n);
     }
 
+    type FramesBody = http_body_util::StreamBody<
+        futures::stream::Iter<
+            std::vec::IntoIter<Result<http_body::Frame<Bytes>, std::convert::Infallible>>,
+        >,
+    >;
+
+    /// A `ServerStream` over the given body frames, as the call path builds it.
+    fn frames_stream<V>(
+        protocol: Protocol,
+        encoding: Option<&str>,
+        frames: Vec<Bytes>,
+    ) -> ServerStream<FramesBody, V> {
+        let frames: Vec<_> = frames
+            .into_iter()
+            .map(|b| Ok(http_body::Frame::data(b)))
+            .collect();
+        ServerStream {
+            element_memory_limit: None,
+            headers: http::HeaderMap::new(),
+            body: http_body_util::StreamBody::new(futures::stream::iter(frames)),
+            frame: Bytes::new(),
+            assembler: response_assembler(protocol, 1024 * 1024),
+            encoding: encoding.map(str::to_owned),
+            compression: CompressionRegistry::default(),
+            codec_format: CodecFormat::Proto,
+            protocol,
+            max_message_size: 1024 * 1024,
+            deadline: None,
+            end: None,
+            saw_body_data: false,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// A large streamed message split across transport frames arrives as
+    /// the sole owner of its allocation; the stream keeps no buffer that
+    /// shares it.
+    #[tokio::test]
+    async fn server_stream_large_message_owns_its_allocation() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        const LEN: usize = 512 * 1024;
+        let wire =
+            Envelope::data(StringValue::from("x".repeat(LEN).as_str()).encode_to_bytes()).encode();
+        let frames = wire.chunks(16 * 1024).map(Bytes::copy_from_slice).collect();
+        let mut stream = frames_stream::<StringValueView<'static>>(Protocol::Connect, None, frames);
+
+        let msg = stream.message().await.unwrap().expect("data envelope");
+        assert_eq!(msg.view().value.len(), LEN);
+        assert!(
+            msg.bytes().is_unique(),
+            "stream shares the message's allocation"
+        );
+        assert!(stream.frame.is_empty());
+    }
+
+    /// Several messages in one body frame are each their own allocation, and
+    /// the stream releases the transport frame once it is consumed.
+    #[tokio::test]
+    async fn server_stream_messages_in_one_frame_are_independent() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut wire = BytesMut::new();
+        for v in ["one", "two"] {
+            wire.extend_from_slice(
+                &Envelope::data(StringValue::from(v).encode_to_bytes()).encode(),
+            );
+        }
+        wire.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"{}")).encode());
+        let body_frame = wire.freeze();
+        let backing = body_frame.clone();
+        let mut stream =
+            frames_stream::<StringValueView<'static>>(Protocol::Connect, None, vec![body_frame]);
+
+        let one = stream.message().await.unwrap().expect("first");
+        let two = stream.message().await.unwrap().expect("second");
+        assert_eq!((one.view().value, two.view().value), ("one", "two"));
+        assert!(
+            stream.message().await.unwrap().is_none(),
+            "clean END_STREAM"
+        );
+        assert!(backing.is_unique(), "consumed transport frame is released");
+    }
+
+    /// gRPC-Web trailers arrive as a 0x80-flagged frame in the body; split
+    /// across transport frames at arbitrary points it still ends the stream
+    /// cleanly with the trailers exposed.
+    #[tokio::test]
+    async fn grpc_web_server_stream_trailer_frame_split_across_frames() {
+        use buffa::Message;
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+        use buffa_types::google::protobuf::StringValue;
+
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::data(StringValue::from("hi").encode_to_bytes()).encode());
+        let trailer = Envelope {
+            flags: crate::envelope::flags::GRPC_WEB_TRAILER,
+            data: Bytes::from_static(b"grpc-status: 0\r\nx-custom: yes\r\n"),
+        };
+        wire.extend_from_slice(&trailer.encode());
+        // Split inside the data payload, inside the trailer header, and
+        // inside the trailer block.
+        let frames = [0, 8, 12, 25, wire.len()]
+            .windows(2)
+            .map(|w| Bytes::copy_from_slice(&wire[w[0]..w[1]]))
+            .collect();
+        let mut stream = frames_stream::<StringValueView<'static>>(Protocol::GrpcWeb, None, frames);
+
+        let msg = stream.message().await.unwrap().expect("data message");
+        assert_eq!(msg.view().value, "hi");
+        assert!(
+            stream.message().await.unwrap().is_none(),
+            "grpc-status 0 is a clean end"
+        );
+        assert_eq!(stream.trailers().unwrap()["x-custom"], "yes");
+    }
+
+    /// A gRPC-Web trailer frame carrying an error status fails the stream
+    /// with that status; a compressed trailer block is decompressed first.
+    #[cfg(feature = "gzip")]
+    #[tokio::test]
+    async fn grpc_web_server_stream_compressed_error_trailer() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let registry = CompressionRegistry::default();
+        let block = registry
+            .compress("gzip", b"grpc-status: 8\r\ngrpc-message: slow%20down\r\n")
+            .unwrap();
+        let trailer = Envelope {
+            flags: crate::envelope::flags::GRPC_WEB_TRAILER | crate::envelope::flags::COMPRESSED,
+            data: block,
+        };
+        let mut stream = frames_stream::<StringValueView<'static>>(
+            Protocol::GrpcWeb,
+            Some("gzip"),
+            vec![trailer.encode()],
+        );
+
+        let err = stream
+            .message()
+            .await
+            .expect_err("error status ends the stream");
+        assert_eq!(err.code, ErrorCode::ResourceExhausted);
+        assert_eq!(err.message.as_deref(), Some("slow down"));
+        assert!(stream.trailers().is_some());
+    }
+
+    /// The trailer frame is metadata, not a message: it is accepted past
+    /// `max_message_size` (within the slack), while a data envelope of the
+    /// same size is rejected on its header.
+    #[tokio::test]
+    async fn grpc_web_server_stream_trailer_not_bound_by_message_limit() {
+        use buffa_types::google::protobuf::__buffa::view::StringValueView;
+
+        let mut block = b"grpc-status: 0\r\n".to_vec();
+        block.extend(std::iter::repeat_n(b'\n', 2000));
+        let trailer = Envelope {
+            flags: crate::envelope::flags::GRPC_WEB_TRAILER,
+            data: Bytes::from(block.clone()),
+        };
+        let mut stream = frames_stream::<StringValueView<'static>>(
+            Protocol::GrpcWeb,
+            None,
+            vec![trailer.encode()],
+        );
+        stream.assembler = response_assembler(Protocol::GrpcWeb, 1024);
+        stream.max_message_size = 1024;
+        assert!(stream.message().await.unwrap().is_none(), "clean end");
+
+        let mut stream = frames_stream::<StringValueView<'static>>(
+            Protocol::GrpcWeb,
+            None,
+            vec![Envelope::data(Bytes::from(block)).encode()],
+        );
+        stream.assembler = response_assembler(Protocol::GrpcWeb, 1024);
+        stream.max_message_size = 1024;
+        let err = stream
+            .message()
+            .await
+            .expect_err("over-limit data envelope");
+        assert_eq!(err.code, ErrorCode::ResourceExhausted);
+
+        // A trailer frame larger than the trailer parser accepts is rejected
+        // on its header, as a trailer, not against the message limit.
+        let mut header = vec![crate::envelope::flags::GRPC_WEB_TRAILER];
+        header.extend_from_slice(&(MAX_GRPC_WEB_TRAILER_SIZE as u32 + 1).to_be_bytes());
+        let mut stream = frames_stream::<StringValueView<'static>>(
+            Protocol::GrpcWeb,
+            None,
+            vec![Bytes::from(header)],
+        );
+        stream.assembler = response_assembler(Protocol::GrpcWeb, 1024);
+        stream.max_message_size = 1024;
+        let err = stream.message().await.expect_err("over-limit trailer");
+        assert_eq!(err.code, ErrorCode::ResourceExhausted);
+        assert!(
+            err.message
+                .as_deref()
+                .is_some_and(|m| m.starts_with("grpc-web trailer size")),
+            "{err:?}"
+        );
+    }
+
     #[tokio::test]
     async fn connect_server_stream_truncated_after_data_errors() {
         use buffa::Message;
@@ -6142,12 +6296,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Connect,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6193,12 +6348,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Connect,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6247,12 +6403,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body: Full::new(body.freeze()),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Connect,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6315,12 +6472,13 @@ mod tests {
             element_memory_limit: None,
             headers,
             body: Full::new(body.freeze()),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Connect,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6381,12 +6539,13 @@ mod tests {
             element_memory_limit: None,
             headers,
             body: Full::new(body.freeze()),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Connect,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6449,12 +6608,13 @@ mod tests {
             element_memory_limit: None,
             headers,
             body: StreamBody::new(futures::stream::iter(frames)),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6509,12 +6669,13 @@ mod tests {
             element_memory_limit: None,
             headers,
             body: StreamBody::new(futures::stream::iter(frames)),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6599,12 +6760,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6657,12 +6819,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: Some(std::time::Instant::now() + Duration::from_secs(5)),
             end: None,
             saw_body_data: false,
@@ -6685,12 +6848,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body: Full::new(Bytes::new()),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6731,12 +6895,13 @@ mod tests {
             element_memory_limit: None,
             headers,
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6771,12 +6936,13 @@ mod tests {
             element_memory_limit: None,
             headers,
             body: Full::new(Bytes::new()),
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6808,12 +6974,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,
@@ -6873,12 +7040,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: Some(std::time::Instant::now() + Duration::from_millis(100)),
             end: None,
             saw_body_data: false,
@@ -6928,12 +7096,13 @@ mod tests {
             element_memory_limit: None,
             headers: http::HeaderMap::new(),
             body,
-            buf: BytesMut::new(),
+            frame: Bytes::new(),
+            assembler: EnvelopeAssembler::new(1024),
             encoding: None,
             compression: CompressionRegistry::new(),
             codec_format: CodecFormat::Proto,
             protocol: Protocol::Grpc,
-            max_message_size: Some(1024),
+            max_message_size: 1024,
             deadline: None,
             end: None,
             saw_body_data: false,

--- a/connectrpc/src/envelope.rs
+++ b/connectrpc/src/envelope.rs
@@ -43,6 +43,21 @@ pub const HEADER_SIZE: usize = 5;
 /// transport splits the payload into multiple DATA frames anyway.
 pub(crate) const MIN_CHAIN_SIZE: usize = 16 * 1024;
 
+/// Size of the per-stream slab that small streamed payloads are copied into
+/// (see [`EnvelopeAssembler`]). 8 KiB is the read block hyper and h2 use
+/// themselves (`tokio_util::codec::FramedRead`, hyper's h1 `INIT_BUFFER_SIZE`).
+/// It bounds what a held small message can keep alive and what an idle
+/// stream retains; it does not decide correctness.
+pub(crate) const READ_SLAB_SIZE: usize = 8 * 1024;
+
+// A shared, exhausted slab is replaced by `BytesMut::reserve` with a block of
+// its *original* capacity, which `bytes` records only as a power-of-two bucket
+// between 1 KiB and 64 KiB; outside that range a rolled slab would not be
+// READ_SLAB_SIZE again.
+const _: () = assert!(
+    READ_SLAB_SIZE.is_power_of_two() && READ_SLAB_SIZE >= 1024 && READ_SLAB_SIZE <= 64 * 1024
+);
+
 /// An envelope-framed message.
 #[derive(Debug, Clone)]
 pub struct Envelope {
@@ -209,20 +224,184 @@ impl Envelope {
     }
 }
 
-/// Decoder for Connect envelope-framed messages on a streaming request.
+/// Incremental envelope decoder fed one transport body frame at a time.
 ///
-/// Implements [`tokio_util::codec::Decoder`] so it can be used with
-/// [`FramedRead`](tokio_util::codec::FramedRead) to turn a raw byte stream
-/// into a stream of decoded (and optionally decompressed) message payloads.
-///
-/// Returns `Ok(None)` when more data is needed — `FramedRead` handles the
-/// async waiting automatically, eliminating manual buffer/loop management.
-pub(crate) struct EnvelopeDecoder {
+/// Unlike [`Envelope::decode_with_limit`], which needs the whole envelope in
+/// one contiguous buffer, this carries at most the 5 header bytes between
+/// frames and checks the declared length against the limit before anything
+/// is allocated. Payloads larger than half of [`READ_SLAB_SIZE`] are
+/// assembled into their own exactly-sized allocation (at most
+/// `min(declared length, 2 × bytes received)` while in flight), so the
+/// emitted [`data`](field@Envelope::data) is the sole owner of its memory
+/// (`Bytes::is_unique`). Smaller payloads are copied into a per-stream slab
+/// of [`READ_SLAB_SIZE`] bytes and split off its front, so the common small
+/// message costs no allocation of its own; a handler that keeps one alive
+/// keeps at most that slab alive, never a large message or the transport's
+/// read buffer, and an idle stream retains at most one slab.
+pub(crate) struct EnvelopeAssembler {
     max_message_size: usize,
+    /// Limit for frames flagged [`flags::GRPC_WEB_TRAILER`], which carry a
+    /// trailer block rather than a message. `None` applies `max_message_size`
+    /// to them like any other envelope (server side, plain gRPC).
+    grpc_web_trailer_limit: Option<usize>,
+    header: [u8; HEADER_SIZE],
+    /// `< HEADER_SIZE` while collecting the header; `== HEADER_SIZE` while
+    /// filling `slab` or `body` up to `expected`.
+    header_len: usize,
+    expected: usize,
+    /// Assembly buffer for a payload too large for the slab.
+    body: Vec<u8>,
+    /// Small payloads are assembled here and split off the front; allocated
+    /// on the first one.
+    slab: Option<BytesMut>,
+}
+
+impl EnvelopeAssembler {
+    pub(crate) fn new(max_message_size: usize) -> Self {
+        Self {
+            max_message_size,
+            grpc_web_trailer_limit: None,
+            header: [0; HEADER_SIZE],
+            header_len: 0,
+            expected: 0,
+            body: Vec::new(),
+            slab: None,
+        }
+    }
+
+    /// Accept gRPC-Web trailer frames up to `limit` bytes regardless of
+    /// `max_message_size` (trailers are metadata, not a message).
+    pub(crate) fn with_grpc_web_trailer_limit(mut self, limit: usize) -> Self {
+        self.grpc_web_trailer_limit = Some(limit);
+        self
+    }
+
+    /// Whether an envelope has started (at least one header byte) and not
+    /// yet been emitted.
+    pub(crate) fn has_partial(&self) -> bool {
+        self.header_len > 0
+    }
+
+    /// Consume bytes from the front of `frame` until one envelope completes
+    /// (`Ok(Some)`; `frame` keeps any bytes after it, so call again) or the
+    /// frame is exhausted (`Ok(None)`). An exhausted `frame` is replaced with
+    /// an empty `Bytes` so the caller's slot never keeps a consumed transport
+    /// frame alive.
+    ///
+    /// # Errors
+    ///
+    /// [`ResourceExhausted`](crate::ErrorCode::ResourceExhausted) as soon as a
+    /// header declares more than the limit, before anything is allocated for
+    /// it. Framing is lost at that point; the stream must be abandoned.
+    pub(crate) fn feed(&mut self, frame: &mut Bytes) -> Result<Option<Envelope>, ConnectError> {
+        if self.header_len < HEADER_SIZE {
+            let take = (HEADER_SIZE - self.header_len).min(frame.len());
+            self.header[self.header_len..self.header_len + take].copy_from_slice(&frame[..take]);
+            frame.advance(take);
+            self.header_len += take;
+            if self.header_len < HEADER_SIZE {
+                *frame = Bytes::new(); // exhausted mid-header
+                return Ok(None);
+            }
+            let [flag_byte, len @ ..] = self.header;
+            let length = u32::from_be_bytes(len) as usize;
+            let (what, limit) = match self.grpc_web_trailer_limit {
+                Some(limit) if flag_byte & flags::GRPC_WEB_TRAILER != 0 => {
+                    ("grpc-web trailer", limit)
+                }
+                _ => ("message", self.max_message_size),
+            };
+            if length > limit {
+                return Err(ConnectError::resource_exhausted(format!(
+                    "{what} size {length} exceeds limit {limit}"
+                )));
+            }
+            self.expected = length;
+        }
+
+        let data = if self.expected == 0 {
+            Some(Bytes::new())
+        } else if self.expected <= READ_SLAB_SIZE / 2 {
+            self.fill_slab(frame)
+        } else {
+            self.fill_body(frame)
+        };
+        if frame.is_empty() {
+            *frame = Bytes::new();
+        }
+        Ok(data.map(|data| {
+            self.header_len = 0;
+            Envelope {
+                flags: self.header[0],
+                data,
+            }
+        }))
+    }
+
+    /// Copy a small payload into the slab; split it off once complete.
+    fn fill_slab(&mut self, frame: &mut Bytes) -> Option<Bytes> {
+        let slab = self
+            .slab
+            .get_or_insert_with(|| BytesMut::with_capacity(READ_SLAB_SIZE));
+        if slab.is_empty() {
+            // Start of a payload. A no-op while the slab has room; once it is
+            // used up this reuses it in place if every message cut from it
+            // has been dropped, and otherwise leaves it to those messages and
+            // allocates a fresh block of the original READ_SLAB_SIZE.
+            slab.reserve(self.expected);
+        }
+        let take = (self.expected - slab.len()).min(frame.len());
+        slab.extend_from_slice(&frame[..take]);
+        frame.advance(take);
+        (slab.len() == self.expected).then(|| slab.split_to(self.expected).freeze())
+    }
+
+    /// Assemble a larger payload into its own exact allocation.
+    fn fill_body(&mut self, frame: &mut Bytes) -> Option<Bytes> {
+        let take = (self.expected - self.body.len()).min(frame.len());
+        if self.body.capacity() - self.body.len() < take {
+            // Reserving the declared length up front would let a peer
+            // allocate `max_message_size` with 5 bytes; doubling from
+            // what has arrived keeps the allocation within 2x of bytes
+            // received, and capping at the declared length makes the
+            // final allocation exact.
+            let target = self.expected.min(
+                self.body
+                    .capacity()
+                    .saturating_mul(2)
+                    .max(self.body.len() + take),
+            );
+            self.body.reserve_exact(target - self.body.len());
+        }
+        self.body.extend_from_slice(&frame[..take]);
+        frame.advance(take);
+        if self.body.len() < self.expected {
+            return None;
+        }
+        // Capacity was capped at `expected` and std's `RawVec` reserves
+        // exactly what is asked, so `len == capacity` here and `Bytes::from`
+        // takes its no-copy, no-`Shared` path; an allocator-aware `Vec` that
+        // over-provided would only cost a `Shared` header, still no copy.
+        Some(Bytes::from(std::mem::take(&mut self.body)))
+    }
+}
+
+/// One item decoded from a streaming request body.
+#[derive(Debug)]
+pub(crate) enum Decoded {
+    Message(Bytes),
+    /// The END_STREAM envelope: terminal. Any further body data is trailing
+    /// garbage to drain (bounded) or reject, never to decode.
+    EndStream,
+}
+
+/// Decoder for Connect envelope-framed messages on a streaming request:
+/// an [`EnvelopeAssembler`] plus END_STREAM detection and per-message
+/// decompression.
+pub(crate) struct EnvelopeDecoder {
+    assembler: EnvelopeAssembler,
     streaming_encoding: Option<String>,
     compression: Arc<CompressionRegistry>,
-    /// Set to `true` once we receive an end-stream envelope; signals EOF.
-    done: bool,
 }
 
 impl EnvelopeDecoder {
@@ -232,43 +411,23 @@ impl EnvelopeDecoder {
         compression: Arc<CompressionRegistry>,
     ) -> Self {
         Self {
-            max_message_size,
+            assembler: EnvelopeAssembler::new(max_message_size),
             streaming_encoding,
             compression,
-            done: false,
         }
     }
 
-    /// Returns `true` once an end-stream envelope has been decoded.
-    ///
-    /// After this point [`decode`](tokio_util::codec::Decoder::decode) always
-    /// returns `Ok(None)` — the decoder will never produce another message.
-    /// Callers must treat this as a terminal state and stop buffering body
-    /// bytes for the decoder; any further data is trailing garbage that
-    /// should be drained (bounded) or rejected, never accumulated.
-    pub(crate) fn is_done(&self) -> bool {
-        self.done
-    }
-}
-
-impl tokio_util::codec::Decoder for EnvelopeDecoder {
-    type Item = Bytes;
-    type Error = ConnectError;
-
-    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Bytes>, ConnectError> {
-        if self.done {
-            return Ok(None);
-        }
-
-        let envelope = match Envelope::decode_with_limit(buf, self.max_message_size)? {
-            Some(envelope) => envelope,
-            None => return Ok(None), // need more data
+    /// Consume bytes from `frame` until one message or END_STREAM is decoded
+    /// (`Ok(Some)`; call again for the rest of the frame, which after
+    /// END_STREAM is trailing bytes) or the frame is exhausted (`Ok(None)`).
+    pub(crate) fn decode(&mut self, frame: &mut Bytes) -> Result<Option<Decoded>, ConnectError> {
+        let Some(envelope) = self.assembler.feed(frame)? else {
+            return Ok(None); // need more data
         };
 
         if envelope.is_end_stream() {
             tracing::trace!("client stream: received end-stream envelope");
-            self.done = true;
-            return Ok(None);
+            return Ok(Some(Decoded::EndStream));
         }
 
         // Decompress if needed
@@ -284,7 +443,7 @@ impl tokio_util::codec::Decoder for EnvelopeDecoder {
             self.compression.decompress_with_limit(
                 encoding,
                 envelope.data,
-                self.max_message_size,
+                self.assembler.max_message_size,
             )?
         } else {
             envelope.data
@@ -295,30 +454,20 @@ impl tokio_util::codec::Decoder for EnvelopeDecoder {
             "client stream: dispatching message to handler"
         );
 
-        Ok(Some(data))
+        Ok(Some(Decoded::Message(data)))
     }
 
-    fn decode_eof(&mut self, buf: &mut BytesMut) -> Result<Option<Bytes>, ConnectError> {
-        // Try to decode any remaining complete envelope in the buffer.
-        match self.decode(buf)? {
-            some @ Some(_) => Ok(some),
-            None => {
-                // Body ended. A client may close the HTTP body without sending
-                // an END_STREAM envelope — the body ending is itself the
-                // end-of-stream signal. Leftover bytes mean a truncated envelope.
-                if !buf.is_empty() {
-                    tracing::debug!(
-                        remaining_bytes = buf.len(),
-                        "client stream: body ended with incomplete envelope"
-                    );
-                    Err(ConnectError::invalid_argument(
-                        "incomplete request envelope",
-                    ))
-                } else {
-                    Ok(None)
-                }
-            }
+    /// The body ended. A client may close the HTTP body without sending an
+    /// END_STREAM envelope — the body ending is itself the end-of-stream
+    /// signal — but ending part-way through an envelope is an error.
+    pub(crate) fn finish(&self) -> Result<(), ConnectError> {
+        if self.assembler.has_partial() {
+            tracing::debug!("client stream: body ended with incomplete envelope");
+            return Err(ConnectError::invalid_argument(
+                "incomplete request envelope",
+            ));
         }
+        Ok(())
     }
 }
 
@@ -480,7 +629,7 @@ fn put_envelope_header(flag: u8, len: u32, dst: &mut BytesMut) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tokio_util::codec::{Decoder, Encoder};
+    use tokio_util::codec::Encoder;
 
     /// Helper: create a decoder with no compression support, suitable for
     /// testing uncompressed envelope framing.
@@ -490,6 +639,14 @@ mod tests {
             None,
             Arc::new(CompressionRegistry::default()),
         )
+    }
+
+    /// Helper: decode the next item and expect it to be a message.
+    fn message(dec: &mut EnvelopeDecoder, frame: &mut Bytes) -> Bytes {
+        match dec.decode(frame).unwrap() {
+            Some(Decoded::Message(data)) => data,
+            other => panic!("expected a message, got {other:?}"),
+        }
     }
 
     // ── Envelope tests ──────────────────────────────────────────────
@@ -549,7 +706,7 @@ mod tests {
         let mut wire = dst;
         wire.put_slice(chained);
         let mut dec = EnvelopeDecoder::new(1024 * 1024, Some("gzip".to_owned()), registry);
-        let decoded = Decoder::decode(&mut dec, &mut wire).unwrap().unwrap();
+        let decoded = message(&mut dec, &mut wire.freeze());
         assert_eq!(decoded.len(), 64 * 1024);
     }
 
@@ -634,7 +791,7 @@ mod tests {
         assert_eq!(wire[0], flags::COMPRESSED);
 
         let mut dec = EnvelopeDecoder::new(1024 * 1024, Some("gzip".to_owned()), registry);
-        let decoded = Decoder::decode(&mut dec, &mut wire).unwrap().unwrap();
+        let decoded = message(&mut dec, &mut wire.freeze());
         assert_eq!(decoded, expected);
     }
 
@@ -800,27 +957,365 @@ mod tests {
         assert!(matches!(result, Ok(None)));
     }
 
+    // ── EnvelopeAssembler tests ─────────────────────────────────────
+
+    /// Feed `frames` in order and collect every envelope, asserting after
+    /// each frame that the in-flight allocation stays within
+    /// `min(declared, 2 × received)`.
+    fn assemble_all(asm: &mut EnvelopeAssembler, frames: &[&[u8]]) -> Vec<Envelope> {
+        let mut out = Vec::new();
+        for f in frames {
+            let mut frame = Bytes::copy_from_slice(f);
+            while let Some(env) = asm.feed(&mut frame).unwrap() {
+                out.push(env);
+            }
+            assert!(
+                frame.is_empty(),
+                "feed returns None only once the frame is consumed"
+            );
+            assert!(
+                asm.body.capacity() <= asm.expected.min(2 * asm.body.len().max(1)),
+                "cap {} len {} expected {}",
+                asm.body.capacity(),
+                asm.body.len(),
+                asm.expected
+            );
+        }
+        out
+    }
+
+    #[test]
+    fn assembler_partial_header_is_partial() {
+        let mut asm = EnvelopeAssembler::new(1024);
+        assert!(!asm.has_partial());
+        assert!(assemble_all(&mut asm, &[&[0u8, 0, 0]]).is_empty());
+        assert!(asm.has_partial());
+    }
+
+    #[test]
+    fn assembler_multiple_envelopes_in_one_frame() {
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::data(Bytes::from_static(b"first")).encode());
+        wire.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"{}")).encode());
+        wire.extend_from_slice(&Envelope::data(Bytes::new()).encode());
+        wire.extend_from_slice(&Envelope::data(Bytes::from_static(b"last")).encode()[..3]);
+        let mut asm = EnvelopeAssembler::new(1024);
+        let out = assemble_all(&mut asm, &[&wire]);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].data, Bytes::from_static(b"first"));
+        assert!(out[1].is_end_stream());
+        assert_eq!(out[1].data, Bytes::from_static(b"{}"));
+        assert!(
+            out[2].data.is_empty(),
+            "zero-length payload is a valid envelope"
+        );
+        assert!(asm.has_partial(), "head of the next envelope is carried");
+    }
+
+    /// A large payload split across many transport frames comes out as one
+    /// exactly-sized, uniquely-owned `Bytes`; the assembler keeps nothing.
+    #[test]
+    fn assembler_payload_split_across_many_frames() {
+        const LEN: usize = 1024 * 1024 + 3;
+        let payload: Vec<u8> = (0..LEN).map(|i| i as u8).collect();
+        let wire = Envelope::data(Bytes::from(payload.clone())).encode();
+        let frames: Vec<&[u8]> = wire.chunks(16 * 1024).collect();
+        let mut asm = EnvelopeAssembler::new(LEN);
+        let out = assemble_all(&mut asm, &frames);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].data.len(), LEN);
+        assert_eq!(&out[0].data[..], &payload[..]);
+        assert!(out[0].data.is_unique(), "message must own its allocation");
+        assert!(!asm.has_partial());
+        assert_eq!(asm.body.capacity(), 0, "assembler retains nothing");
+    }
+
+    /// Small payloads are cut from a per-stream slab: they do not reference
+    /// the transport frame, a held one shares at most its own slab, and the
+    /// assembler keeps no reference to a slab it has moved past.
+    #[test]
+    fn assembler_small_messages_come_from_a_bounded_slab() {
+        let envelope = Envelope::data(Bytes::from(vec![7u8; 100])).encode();
+        let per_slab = READ_SLAB_SIZE / 100;
+        let mut wire = BytesMut::new();
+        for _ in 0..2 * per_slab {
+            wire.extend_from_slice(&envelope);
+        }
+        let mut frame = wire.freeze();
+        let backing = frame.clone();
+        let mut asm = EnvelopeAssembler::new(1024);
+        let mut out = Vec::new();
+        while let Some(env) = asm.feed(&mut frame).unwrap() {
+            out.push(env.data);
+        }
+        assert_eq!(out.len(), 2 * per_slab);
+        drop(frame);
+        assert!(backing.is_unique(), "no message references the frame");
+        let held = out.swap_remove(0);
+        assert!(!held.is_unique(), "neighbours share the first slab");
+        drop(out);
+        assert!(held.is_unique(), "assembler moved past the first slab");
+        assert_eq!(&held[..], &[7u8; 100][..]);
+    }
+
+    /// The slab/own-allocation threshold is half the slab: a 4096-byte
+    /// payload is cut from the slab (and shares it with its neighbour), a
+    /// 4097-byte payload is its own allocation.
+    #[test]
+    fn assembler_slab_threshold() {
+        let at = vec![3u8; READ_SLAB_SIZE / 2];
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::data(Bytes::from(at.clone())).encode());
+        wire.extend_from_slice(&Envelope::data(Bytes::from(at.clone())).encode());
+        let mut asm = EnvelopeAssembler::new(READ_SLAB_SIZE);
+        let out = assemble_all(&mut asm, &[&wire]);
+        assert_eq!(out.len(), 2);
+        assert_eq!(&out[0].data[..], &at[..]);
+        assert!(
+            !out[0].data.is_unique(),
+            "slab-cut, shared with its neighbour"
+        );
+        assert_eq!(
+            out[1].data.as_ptr() as usize,
+            out[0].data.as_ptr() as usize + at.len(),
+            "both halves of one slab"
+        );
+        assert_eq!(asm.body.capacity(), 0);
+
+        let over = vec![4u8; READ_SLAB_SIZE / 2 + 1];
+        let wire = Envelope::data(Bytes::from(over.clone())).encode();
+        let mut asm = EnvelopeAssembler::new(READ_SLAB_SIZE);
+        let out = assemble_all(&mut asm, &[&wire]);
+        assert_eq!(&out[0].data[..], &over[..]);
+        assert!(out[0].data.is_unique(), "own exact allocation");
+        assert!(asm.slab.is_none(), "large path never touches the slab");
+        assert_eq!(asm.body.capacity(), 0);
+    }
+
+    /// A large payload between two small ones goes around the slab: the
+    /// second small message is cut from the same slab, right after the first.
+    /// The frames that start and complete the large payload also carry the
+    /// small ones (straddling), and every envelope is still delivered.
+    #[test]
+    fn assembler_large_payload_bypasses_the_slab() {
+        let big = vec![1u8; 100 * 1024];
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::data(Bytes::from_static(b"one")).encode());
+        wire.extend_from_slice(&Envelope::data(Bytes::from(big.clone())).encode());
+        wire.extend_from_slice(&Envelope::data(Bytes::from_static(b"two")).encode());
+        let frames: Vec<&[u8]> = wire.chunks(16 * 1024).collect();
+        let mut asm = EnvelopeAssembler::new(1024 * 1024);
+        let out = assemble_all(&mut asm, &frames);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].data, Bytes::from_static(b"one"));
+        assert_eq!(&out[1].data[..], &big[..]);
+        assert_eq!(out[2].data, Bytes::from_static(b"two"));
+        assert!(out[1].data.is_unique(), "large payload owns its allocation");
+        assert_eq!(
+            out[2].data.as_ptr() as usize,
+            out[0].data.as_ptr() as usize + 3,
+            "second small message continues the first slab"
+        );
+    }
+
+    /// A small payload split across frames whose first fragment arrives when
+    /// the slab is nearly full is still assembled contiguously: the slab is
+    /// rolled to exactly one fresh READ_SLAB_SIZE block (messages held) or
+    /// reclaimed in place at its original size (messages dropped) at the
+    /// start of the payload, never part-way through it.
+    #[test]
+    fn assembler_split_small_payload_at_slab_roll() {
+        let filler = Envelope::data(Bytes::from(vec![7u8; 100])).encode();
+        let per_slab = READ_SLAB_SIZE / 100;
+        let payload: Vec<u8> = (0..READ_SLAB_SIZE / 2).map(|i| i as u8).collect();
+        let wire = Envelope::data(Bytes::from(payload.clone())).encode();
+        let third = wire.len() / 3;
+        for hold in [true, false] {
+            let mut asm = EnvelopeAssembler::new(READ_SLAB_SIZE);
+            let mut fill = BytesMut::new();
+            for _ in 0..per_slab {
+                fill.extend_from_slice(&filler);
+            }
+            let held = assemble_all(&mut asm, &[&fill]);
+            assert_eq!(held.len(), per_slab);
+            let first = held[0].data.as_ptr() as usize;
+            assert!(asm.slab.as_ref().unwrap().capacity() < payload.len());
+            let held = hold.then_some(held);
+            let out = assemble_all(
+                &mut asm,
+                &[&wire[..third], &wire[third..2 * third], &wire[2 * third..]],
+            );
+            assert_eq!(out.len(), 1);
+            assert_eq!(&out[0].data[..], &payload[..], "hold={hold}");
+            let at = out[0].data.as_ptr() as usize;
+            if hold {
+                assert!(
+                    !(first..first + READ_SLAB_SIZE).contains(&at),
+                    "rolled to a fresh slab"
+                );
+            } else {
+                assert_eq!(at, first, "reclaimed the released slab in place");
+            }
+            assert_eq!(
+                asm.slab.as_ref().unwrap().capacity(),
+                READ_SLAB_SIZE - payload.len(),
+                "rolled or reclaimed slab has the original READ_SLAB_SIZE (hold={hold})"
+            );
+            drop(held);
+        }
+    }
+
+    /// A zero-length payload allocates nothing: no slab, no body.
+    #[test]
+    fn assembler_empty_payload_allocates_nothing() {
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::data(Bytes::new()).encode());
+        wire.extend_from_slice(&Envelope::end_stream(Bytes::new()).encode());
+        let mut asm = EnvelopeAssembler::new(1024);
+        let out = assemble_all(&mut asm, &[&wire]);
+        assert_eq!(out.len(), 2);
+        assert!(out[0].data.is_empty() && out[1].data.is_empty());
+        assert!(out[1].is_end_stream());
+        assert!(asm.slab.is_none());
+        assert_eq!(asm.body.capacity(), 0);
+    }
+
+    /// An over-limit length is rejected on the header, before any payload
+    /// byte is buffered or allocated for.
+    #[test]
+    fn assembler_rejects_over_limit_before_allocating() {
+        let mut wire = vec![0u8; HEADER_SIZE];
+        wire[1..].copy_from_slice(&4096u32.to_be_bytes());
+        wire.extend_from_slice(&[0xAA; 4096]);
+        let mut asm = EnvelopeAssembler::new(1024);
+        let mut frame = Bytes::from(wire);
+        let err = asm.feed(&mut frame).unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::ResourceExhausted);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("message size 4096 exceeds limit 1024")
+        );
+        assert_eq!(asm.body.capacity(), 0, "nothing allocated for it");
+        assert_eq!(frame.len(), 4096, "payload left unread");
+    }
+
+    #[test]
+    fn assembler_grpc_web_trailer_limit() {
+        let block = vec![b'x'; 2000];
+        let trailer = Envelope {
+            flags: flags::GRPC_WEB_TRAILER,
+            data: Bytes::from(block.clone()),
+        }
+        .encode();
+        // Without the allowance the trailer frame is just an envelope.
+        let mut asm = EnvelopeAssembler::new(1024);
+        let err = asm.feed(&mut trailer.clone()).unwrap_err();
+        assert_eq!(
+            err.message.as_deref(),
+            Some("message size 2000 exceeds limit 1024")
+        );
+        // With it, trailer frames get their own limit; data frames do not.
+        let mut asm = EnvelopeAssembler::new(1024).with_grpc_web_trailer_limit(4096);
+        let out = assemble_all(&mut asm, &[&trailer]);
+        assert_eq!(out[0].flags, flags::GRPC_WEB_TRAILER);
+        assert_eq!(&out[0].data[..], &block[..]);
+        let data = Envelope::data(Bytes::from(block)).encode();
+        assert!(asm.feed(&mut data.clone()).is_err());
+        // A trailer frame over its own limit says so.
+        let mut asm = EnvelopeAssembler::new(1024).with_grpc_web_trailer_limit(1500);
+        let err = asm.feed(&mut trailer.clone()).unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::ResourceExhausted);
+        assert_eq!(
+            err.message.as_deref(),
+            Some("grpc-web trailer size 2000 exceeds limit 1500")
+        );
+    }
+
+    /// Whatever the frame boundaries, the assembler yields exactly what
+    /// `Envelope::decode` yields over the contiguous wire.
+    #[test]
+    fn assembler_matches_contiguous_decode_at_every_split() {
+        let mut wire = BytesMut::new();
+        for env in [
+            Envelope::data(Bytes::new()),
+            Envelope::data(Bytes::from_static(b"x")),
+            Envelope::data(Bytes::from(vec![9u8; 3000])),
+            Envelope::end_stream(Bytes::from_static(b"{}")),
+            Envelope {
+                flags: flags::GRPC_WEB_TRAILER,
+                data: Bytes::from_static(b"grpc-status: 0\r\n"),
+            },
+            Envelope::data(Bytes::from_static(b"tail")),
+        ] {
+            wire.extend_from_slice(&env.encode());
+        }
+        let mut contiguous = wire.clone();
+        let mut expected = Vec::new();
+        while let Some(env) = Envelope::decode(&mut contiguous).unwrap() {
+            expected.push((env.flags, env.data));
+        }
+        assert_eq!(expected.len(), 6);
+
+        let irregular: Vec<usize> = [0, 1, 6, 7, 13, 2900, 3016, 3017, 3030, wire.len()].into();
+        let mut splits: Vec<Vec<&[u8]>> = [1, 3, HEADER_SIZE, 7, 4096]
+            .iter()
+            .map(|&n| wire.chunks(n).collect())
+            .collect();
+        splits.push(irregular.windows(2).map(|w| &wire[w[0]..w[1]]).collect());
+        for frames in splits {
+            let mut asm = EnvelopeAssembler::new(4096);
+            let got: Vec<_> = assemble_all(&mut asm, &frames)
+                .into_iter()
+                .map(|e| (e.flags, e.data))
+                .collect();
+            assert_eq!(
+                got,
+                expected,
+                "frames of {:?}",
+                frames.first().map(|f| f.len())
+            );
+            assert!(!asm.has_partial());
+        }
+    }
+
+    /// `feed` never leaves an exhausted transport frame alive in the caller's
+    /// slot, whether it stopped mid-header or mid-payload.
+    #[test]
+    fn assembler_releases_exhausted_frame() {
+        let wire = Envelope::data(Bytes::from(vec![7u8; 64])).encode();
+        for end in [3, 40] {
+            let mut asm = EnvelopeAssembler::new(1024);
+            let mut slot = Bytes::copy_from_slice(&wire[..end]);
+            let backing = slot.clone();
+            assert!(asm.feed(&mut slot).unwrap().is_none());
+            assert!(slot.is_empty());
+            assert!(
+                backing.is_unique(),
+                "exhausted frame still referenced from the slot (end={end})"
+            );
+        }
+    }
+
     // ── EnvelopeDecoder tests ───────────────────────────────────────
 
     #[test]
     fn test_decoder_complete_message() {
         let mut dec = decoder(1024);
-        let envelope = Envelope::data(Bytes::from_static(b"hello"));
-        let mut buf = BytesMut::from(&envelope.encode()[..]);
+        let mut frame = Envelope::data(Bytes::from_static(b"hello")).encode();
 
-        let result = dec.decode(&mut buf).unwrap();
-        assert_eq!(result.unwrap(), Bytes::from_static(b"hello"));
-        assert!(buf.is_empty());
+        assert_eq!(message(&mut dec, &mut frame), Bytes::from_static(b"hello"));
+        assert!(frame.is_empty());
+        assert!(dec.finish().is_ok());
     }
 
     #[test]
     fn test_decoder_incomplete_header() {
         let mut dec = decoder(1024);
         // Only 3 bytes — not enough for the 5-byte header
-        let mut buf = BytesMut::from(&[0u8, 0, 0][..]);
+        let mut frame = Bytes::from_static(&[0u8, 0, 0]);
 
-        assert!(dec.decode(&mut buf).unwrap().is_none());
-        assert_eq!(buf.len(), 3, "buffer should be untouched");
+        assert!(dec.decode(&mut frame).unwrap().is_none());
+        assert!(frame.is_empty(), "frame is consumed into the header carry");
     }
 
     #[test]
@@ -831,47 +1326,59 @@ mod tests {
         buf.put_u8(flags::DATA);
         buf.put_u32(10);
         buf.put_slice(&[1, 2, 3]);
+        let mut frame = buf.freeze();
 
-        assert!(dec.decode(&mut buf).unwrap().is_none());
-        assert_eq!(buf.len(), 8, "buffer should be untouched");
+        assert!(dec.decode(&mut frame).unwrap().is_none());
+        assert!(frame.is_empty());
+        // The rest arrives in a later frame.
+        let mut rest = Bytes::from_static(&[4, 5, 6, 7, 8, 9, 10]);
+        let msg = message(&mut dec, &mut rest);
+        assert_eq!(&msg[..], &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     }
 
     #[test]
     fn test_decoder_end_stream_signals_eof() {
         let mut dec = decoder(1024);
-        let envelope = Envelope::end_stream(Bytes::from_static(b"{}"));
-        let mut buf = BytesMut::from(&envelope.encode()[..]);
+        let mut wire = BytesMut::new();
+        wire.extend_from_slice(&Envelope::end_stream(Bytes::from_static(b"{}")).encode());
+        wire.extend_from_slice(b"trailing");
+        let mut frame = wire.freeze();
 
-        // End-stream envelope yields None (EOF signal)
-        assert!(dec.decode(&mut buf).unwrap().is_none());
-        // Subsequent calls also yield None
-        assert!(dec.decode(&mut buf).unwrap().is_none());
+        // End-stream is terminal and leaves the trailing bytes in the frame
+        // for the caller to account for.
+        assert!(matches!(
+            dec.decode(&mut frame).unwrap(),
+            Some(Decoded::EndStream)
+        ));
+        assert_eq!(&frame[..], b"trailing");
+        assert!(dec.finish().is_ok());
     }
 
     #[test]
     fn test_decoder_message_exceeds_size_limit() {
         let mut dec = decoder(4); // max 4 bytes per message
-        let envelope = Envelope::data(Bytes::from_static(b"too long"));
-        let mut buf = BytesMut::from(&envelope.encode()[..]);
+        let mut frame = Envelope::data(Bytes::from_static(b"too long")).encode();
 
-        let err = dec.decode(&mut buf).unwrap_err();
+        let err = dec.decode(&mut frame).unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::ResourceExhausted);
     }
 
     #[test]
-    fn test_decoder_multiple_envelopes_in_buffer() {
+    fn test_decoder_multiple_envelopes_in_frame() {
         let mut dec = decoder(1024);
         let e1 = Envelope::data(Bytes::from_static(b"first"));
         let e2 = Envelope::data(Bytes::from_static(b"second"));
         let mut buf = BytesMut::new();
         buf.extend_from_slice(&e1.encode());
         buf.extend_from_slice(&e2.encode());
+        let mut frame = buf.freeze();
 
-        let r1 = dec.decode(&mut buf).unwrap().unwrap();
+        let r1 = message(&mut dec, &mut frame);
         assert_eq!(r1, Bytes::from_static(b"first"));
-        let r2 = dec.decode(&mut buf).unwrap().unwrap();
+        let r2 = message(&mut dec, &mut frame);
         assert_eq!(r2, Bytes::from_static(b"second"));
-        assert!(buf.is_empty());
+        assert!(dec.decode(&mut frame).unwrap().is_none());
+        assert!(frame.is_empty());
     }
 
     #[test]
@@ -882,38 +1389,46 @@ mod tests {
         let mut buf = BytesMut::new();
         buf.extend_from_slice(&data_env.encode());
         buf.extend_from_slice(&end_env.encode());
+        let mut frame = buf.freeze();
 
-        let r1 = dec.decode(&mut buf).unwrap().unwrap();
+        let r1 = message(&mut dec, &mut frame);
         assert_eq!(r1, Bytes::from_static(b"msg"));
-        // End-stream yields None
-        assert!(dec.decode(&mut buf).unwrap().is_none());
+        assert!(matches!(
+            dec.decode(&mut frame).unwrap(),
+            Some(Decoded::EndStream)
+        ));
+        assert!(frame.is_empty());
     }
 
     #[test]
-    fn test_decode_eof_empty_buffer() {
-        let mut dec = decoder(1024);
-        let mut buf = BytesMut::new();
-        // Empty buffer at EOF is fine — clean end of stream
-        assert!(dec.decode_eof(&mut buf).unwrap().is_none());
+    fn test_finish_without_data() {
+        let dec = decoder(1024);
+        // Body ending before any envelope is a clean end of stream
+        assert!(dec.finish().is_ok());
     }
 
     #[test]
-    fn test_decode_eof_with_complete_envelope() {
-        let mut dec = decoder(1024);
-        let envelope = Envelope::data(Bytes::from_static(b"final"));
-        let mut buf = BytesMut::from(&envelope.encode()[..]);
-
-        let result = dec.decode_eof(&mut buf).unwrap();
-        assert_eq!(result.unwrap(), Bytes::from_static(b"final"));
-    }
-
-    #[test]
-    fn test_decode_eof_with_leftover_bytes() {
+    fn test_finish_with_partial_header() {
         let mut dec = decoder(1024);
         // Partial header — body ended with incomplete envelope
-        let mut buf = BytesMut::from(&[0u8, 0, 0][..]);
+        assert!(
+            dec.decode(&mut Bytes::from_static(&[0u8, 0, 0]))
+                .unwrap()
+                .is_none()
+        );
 
-        let err = dec.decode_eof(&mut buf).unwrap_err();
+        let err = dec.finish().unwrap_err();
+        assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
+        assert_eq!(err.message.as_deref(), Some("incomplete request envelope"));
+    }
+
+    #[test]
+    fn test_finish_with_partial_payload() {
+        let mut dec = decoder(1024);
+        let wire = Envelope::data(Bytes::from_static(b"hello")).encode();
+        assert!(dec.decode(&mut wire.slice(..7)).unwrap().is_none());
+
+        let err = dec.finish().unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
     }
 
@@ -921,10 +1436,9 @@ mod tests {
     fn test_decoder_compressed_without_encoding_header() {
         let mut dec = decoder(1024);
         // Compressed flag set but decoder has no streaming_encoding
-        let envelope = Envelope::compressed(Bytes::from_static(b"data"));
-        let mut buf = BytesMut::from(&envelope.encode()[..]);
+        let mut frame = Envelope::compressed(Bytes::from_static(b"data")).encode();
 
-        let err = dec.decode(&mut buf).unwrap_err();
+        let err = dec.decode(&mut frame).unwrap_err();
         assert_eq!(err.code, crate::error::ErrorCode::Internal);
     }
 
@@ -999,10 +1513,11 @@ mod tests {
         let original = Bytes::from_static(b"roundtrip test data");
         let mut buf = BytesMut::new();
         enc.encode(original.clone(), &mut buf).unwrap();
+        let mut frame = buf.freeze();
 
-        let decoded = dec.decode(&mut buf).unwrap().unwrap();
+        let decoded = message(&mut dec, &mut frame);
         assert_eq!(decoded, original);
-        assert!(buf.is_empty());
+        assert!(frame.is_empty());
     }
 
     #[test]
@@ -1017,10 +1532,11 @@ mod tests {
 
         // Decode both with a decoder
         let mut dec = decoder(1024);
-        let r1 = dec.decode(&mut buf).unwrap().unwrap();
+        let mut frame = buf.freeze();
+        let r1 = message(&mut dec, &mut frame);
         assert_eq!(r1, Bytes::from_static(b"one"));
-        let r2 = dec.decode(&mut buf).unwrap().unwrap();
+        let r2 = message(&mut dec, &mut frame);
         assert_eq!(r2, Bytes::from_static(b"two"));
-        assert!(buf.is_empty());
+        assert!(frame.is_empty());
     }
 }

--- a/connectrpc/src/service.rs
+++ b/connectrpc/src/service.rs
@@ -41,7 +41,6 @@ use std::task::Poll;
 use std::time::Duration;
 
 use bytes::Bytes;
-use bytes::BytesMut;
 use futures::{Stream, StreamExt};
 use http::Method;
 use http::Request;
@@ -53,7 +52,6 @@ use http_body::Frame;
 use http_body_util::BodyExt;
 use http_body_util::Full;
 use serde::Serialize;
-use tokio_util::codec::Decoder as _;
 use tracing::Instrument;
 
 use crate::codec::CodecFormat;
@@ -63,6 +61,7 @@ use crate::compression::CompressionPolicy;
 use crate::compression::CompressionRegistry;
 use crate::deadline::DeadlinePolicy;
 use crate::dispatcher::{Dispatcher, MethodDescriptor};
+use crate::envelope::Decoded;
 use crate::envelope::Envelope;
 use crate::envelope::EnvelopeDecoder;
 use crate::error::ConnectError;
@@ -2895,7 +2894,6 @@ enum ReadMode {
 /// rest of the body (bounded) once the decoder is finished.
 struct BodyReader {
     decoder: EnvelopeDecoder,
-    buf: BytesMut,
     tx: tokio::sync::mpsc::Sender<Result<Bytes, ConnectError>>,
     mode: ReadMode,
 }
@@ -2909,7 +2907,6 @@ impl BodyReader {
     ) -> Self {
         Self {
             decoder: EnvelopeDecoder::new(max_message_size, streaming_encoding, compression),
-            buf: BytesMut::new(),
             tx,
             mode: ReadMode::Decoding,
         }
@@ -2919,17 +2916,17 @@ impl BodyReader {
     ///
     /// Returns [`ControlFlow::Break`] when the reader should stop reading the
     /// body because the post-decoder drain limit was exceeded.
-    async fn on_data(&mut self, data: Bytes) -> ControlFlow<()> {
+    async fn on_data(&mut self, mut data: Bytes) -> ControlFlow<()> {
+        if matches!(self.mode, ReadMode::Decoding) {
+            // May switch to draining; what is left of `data` (bytes after
+            // END_STREAM or a decode error) is drained below with the frame.
+            self.decode_available(&mut data).await;
+        }
         match &mut self.mode {
-            ReadMode::Decoding => {
-                self.buf.extend_from_slice(&data);
-                self.decode_available().await;
-                ControlFlow::Continue(())
-            }
             ReadMode::Draining {
                 drained,
                 pending_trailing_data_warn,
-            } => {
+            } if !data.is_empty() => {
                 if *pending_trailing_data_warn {
                     tracing::warn!(
                         trailing_bytes = data.len(),
@@ -2947,42 +2944,29 @@ impl BodyReader {
                 }
                 ControlFlow::Continue(())
             }
+            _ => ControlFlow::Continue(()),
         }
     }
 
-    /// Handle the end of the request body: flush any remaining complete
-    /// messages out of the decoder. A client may end the body without an
+    /// Handle the end of the request body. Every complete message has already
+    /// been forwarded frame by frame; a client may end the body without an
     /// END_STREAM envelope — the body ending is itself the end-of-stream
-    /// signal.
+    /// signal — but not part-way through an envelope.
     async fn on_eof(&mut self) {
         if !matches!(self.mode, ReadMode::Decoding) {
             return;
         }
-        loop {
-            match self.decoder.decode_eof(&mut self.buf) {
-                Ok(Some(data)) => {
-                    // A send failure (handler dropped the stream) just ends
-                    // the flush early — the caller breaks out of the read
-                    // loop right after `on_eof`, so no mode change is needed.
-                    if self.tx.send(Ok(data)).await.is_err() {
-                        return;
-                    }
-                }
-                Ok(None) => return,
-                Err(e) => {
-                    let _ = self.tx.send(Err(e)).await;
-                    return;
-                }
-            }
+        if let Err(e) = self.decoder.finish() {
+            let _ = self.tx.send(Err(e)).await;
         }
     }
 
-    /// Decode and forward every complete message currently buffered,
-    /// switching to drain mode if the decoder finishes.
-    async fn decode_available(&mut self) {
+    /// Decode and forward every complete message in `frame`, switching to
+    /// drain mode if the decoder finishes.
+    async fn decode_available(&mut self, frame: &mut Bytes) {
         loop {
-            match self.decoder.decode(&mut self.buf) {
-                Ok(Some(data)) => {
+            match self.decoder.decode(frame) {
+                Ok(Some(Decoded::Message(data))) => {
                     if self.tx.send(Ok(data)).await.is_err() {
                         // The handler dropped the request stream; the rest of
                         // the body is drained without inspection.
@@ -2990,10 +2974,9 @@ impl BodyReader {
                         return;
                     }
                 }
-                Ok(None) if self.decoder.is_done() => {
-                    // The END_STREAM envelope was decoded — the stream is
-                    // finished, and any further request data is a protocol
-                    // violation by the client.
+                Ok(Some(Decoded::EndStream)) => {
+                    // The stream is finished; any further request data is a
+                    // protocol violation by the client.
                     self.enter_drain_mode(true);
                     return;
                 }
@@ -3007,23 +2990,12 @@ impl BodyReader {
         }
     }
 
-    /// Switch to bounded drain mode, releasing any bytes the decoder still
-    /// holds (e.g. trailing data that arrived in the same body frame as
-    /// END_STREAM, or an undecoded partial envelope after a decode error)
-    /// instead of keeping them resident for the duration of the drain.
+    /// Switch to bounded drain mode; `end_stream` arms the one-time warning
+    /// for request data after END_STREAM.
     fn enter_drain_mode(&mut self, end_stream: bool) {
-        let mut pending_trailing_data_warn = end_stream;
-        if pending_trailing_data_warn && !self.buf.is_empty() {
-            tracing::warn!(
-                trailing_bytes = self.buf.len(),
-                "client sent request data after the END_STREAM envelope; discarding"
-            );
-            pending_trailing_data_warn = false;
-        }
-        self.buf = BytesMut::new();
         self.mode = ReadMode::Draining {
             drained: 0,
-            pending_trailing_data_warn,
+            pending_trailing_data_warn: end_stream,
         };
     }
 
@@ -5415,6 +5387,107 @@ mod tests {
             "reader pulled {pulled} bytes after END_STREAM (expected at most \
              {max_expected}); trailing data is being buffered without bound"
         );
+    }
+
+    fn test_reader() -> (
+        BodyReader,
+        tokio::sync::mpsc::Receiver<Result<Bytes, ConnectError>>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+        let reader = BodyReader::new(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            None,
+            Arc::new(CompressionRegistry::new()),
+            tx,
+        );
+        (reader, rx)
+    }
+
+    /// A large message that arrives over many transport frames reaches the
+    /// handler as the sole owner of its allocation: the reader keeps no
+    /// buffer that shares it, and nothing is left buffered once it is out.
+    #[tokio::test]
+    async fn test_body_reader_large_message_owns_its_allocation() {
+        let (mut reader, mut rx) = test_reader();
+        let payload = Bytes::from(vec![0x42_u8; 1024 * 1024]);
+        let wire = Envelope::data(payload.clone()).encode();
+        for chunk in wire.chunks(16 * 1024) {
+            assert!(
+                reader
+                    .on_data(Bytes::copy_from_slice(chunk))
+                    .await
+                    .is_continue()
+            );
+        }
+
+        let msg = rx.recv().await.expect("message").expect("decodes");
+        assert_eq!(msg, payload, "message must arrive intact");
+        assert!(msg.is_unique(), "reader shares the message's allocation");
+        assert!(reader.decoder.finish().is_ok(), "nothing left buffered");
+    }
+
+    /// A compressed envelope split across frames is reassembled and
+    /// decompressed.
+    #[cfg(feature = "gzip")]
+    #[tokio::test]
+    async fn test_body_reader_compressed_message_across_frames() {
+        let registry = Arc::new(CompressionRegistry::default());
+        let payload = Bytes::from(vec![b'z'; 64 * 1024]);
+        let compressed = registry
+            .compress("gzip", &payload)
+            .expect("gzip compresses");
+        let wire = Envelope::compressed(compressed).encode();
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        let mut reader = BodyReader::new(
+            DEFAULT_MAX_MESSAGE_SIZE,
+            Some("gzip".to_owned()),
+            registry,
+            tx,
+        );
+        for chunk in wire.chunks(7) {
+            assert!(
+                reader
+                    .on_data(Bytes::copy_from_slice(chunk))
+                    .await
+                    .is_continue()
+            );
+        }
+        let msg = rx.recv().await.expect("message").expect("decodes");
+        assert_eq!(msg, payload);
+    }
+
+    /// A body that ends part-way through an envelope surfaces
+    /// `invalid_argument` to the handler rather than a clean end of stream.
+    #[tokio::test]
+    async fn test_body_reader_incomplete_envelope_at_eof() {
+        let wire = Envelope::data(Bytes::from_static(b"hello world")).encode();
+        let mut frames = std::collections::VecDeque::new();
+        frames.push_back(wire.slice(..3));
+        frames.push_back(wire.slice(3..9));
+        let body = CountingBody {
+            frames,
+            pulled: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+        };
+
+        let (mut request_stream, reader_task) = spawn_body_reader(
+            body,
+            DEFAULT_MAX_MESSAGE_SIZE,
+            None,
+            Arc::new(CompressionRegistry::new()),
+        );
+        let err = request_stream
+            .next()
+            .await
+            .expect("an item must be delivered")
+            .expect_err("a truncated envelope is an error");
+        assert_eq!(err.code, crate::error::ErrorCode::InvalidArgument);
+        assert_eq!(err.message.as_deref(), Some("incomplete request envelope"));
+        assert!(request_stream.next().await.is_none());
+        reader_task
+            .expect("tests run inside a tokio runtime")
+            .await
+            .expect("reader task must not panic");
     }
 
     /// An END_STREAM envelope with no preceding messages (the typical


### PR DESCRIPTION
The server request reader (`BodyReader`) and the client response stream (`ServerStream`) accumulated body frames in a per-stream `BytesMut` and handed each message out as a `split_to().freeze()` slice of it. That buffer grows to the largest message, never shrinks, and stays referenced by the reader until the stream ends — so a long-lived stream that once carried a multi-MiB message keeps that allocation alive after the handler has dropped the message (#301 measured 32 MiB/stream; GiBs per pod in the reported service). Every multi-frame message was also copied through a shared doubling buffer.

This replaces the buffer with a small `EnvelopeAssembler` fed one transport frame at a time:

- carries at most the 5 envelope-header bytes between frames; once the header is complete, rejects `len > max_message_size` **before allocating** (same `resource_exhausted` text as `Envelope::decode_with_limit`);
- payloads larger than 4 KiB are copied into one `Vec` per message whose capacity grows as `min(declared, 2 × received)` — a peer that sends 5 bytes cannot make the receiver allocate `max_message_size`, and the final allocation is exact — and emitted as `Bytes::from(vec)`: the message is the sole owner of its memory (`is_unique()`) and the reader retains nothing of it;
- payloads of 4 KiB or less are copied into a lazily-allocated 8 KiB per-stream slab and handed out with `split_to().freeze()`. That costs one `Shared` allocation per slab rather than per message, and `BytesMut::reserve` reclaims the slab in place once every message cut from it has been dropped (otherwise the reader rolls a fresh 8 KiB block). Steady-state small messages therefore do not allocate; a held small message keeps at most its 8 KiB slab alive; an idle stream retains at most one slab. The slab size is a compile-time constant checked against `bytes`' original-capacity bucketing;
- gRPC-Web trailer frames come out of the same assembler as ordinary `0x80` envelopes, which deletes the client's sentinel peeks and `max_buf_size` accounting; trailers are capped at the parser's existing 1 MiB `MAX_GRPC_WEB_TRAILER_SIZE` on the header;
- `Envelope::decode*` and all public API are untouched; `EnvelopeDecoder` (crate-private) is now frame-fed and returns `Decoded::{Message, EndStream}` instead of implementing `tokio_util`'s `Decoder`.

| reader loop, 16 KiB frames (jemalloc) | main | this PR |
|---|---|---|
| 1 MiB message | 135 µs, reader retains 2 MiB | 109 µs, retains 0, message `is_unique()` |
| 20 × 1 MiB, previous still held | 191 µs/msg | 109 µs/msg |
| 3 MiB then 100 × 300 B | retains 4 MiB until stream end | retains ≤ 8 KiB |
| 300 B single-frame message, previous dropped / held | 104 ns, 0 allocs / 172 ns, 2 allocs | 98 ns / 105 ns, 0 allocs (steady state) |
| 300 B messages packed in 256 KiB h1 chunks | 95 ns | 69 ns |
| 300 B messages straddling 1000 B gRPC-Web chunks | 81 ns | 77 ns |
| `benches/rpc` unary / streaming arms | — | within noise; `client_stream_many_small` −2…−3.5% |

Trade-offs, stated plainly: an idle stream that has carried a small message now keeps up to 8 KiB (10k idle streams ≈ 80 MiB) where the first revision of this PR kept 0 and `main` keeps up to 2× its largest message; and because each large message is a fresh exact allocation, `client_stream_large` (10 × 1 MiB) is +10–19% under **glibc malloc** end-to-end (page-fault/munmap churn) while flat-to-slightly-faster under jemalloc — see the [perf evaluation comment](https://github.com/connectrpc/connect-rust/pull/302#issuecomment-5647677114) for the full matrix.

Compatibility: no public API or wire change; error codes and texts preserved except that the client-side "response buffer exceeds limit" error no longer exists (memory is bounded per envelope, whose over-limit header reports "message size N exceeds limit M" as before) and a gRPC-Web trailer frame larger than 1 MiB now fails on its header with `resource_exhausted`. The workspace `bytes` floor moves to 1.6.1 only because the new tests rely on `Bytes::is_unique` being correct for `BytesMut`-derived values. Conformance (v1.0.5): server 3600, client connect 2580 / grpc 1454 / grpc-web 2838 passed, 0 failed.

Alternative to #301, and built on it — its analysis of the pinning mechanism and its `is_unique()` tests are what this builds on; the difference is that the invariant is structural rather than restored by a 64 KiB release heuristic, so the completing-frame-carries-the-next-header case, all-large streams, and large h1 chunks need no special handling.
